### PR TITLE
Fix conflicting definition of SdkLog from config files

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 [submodule "FreeRTOS-Plus/Source/Application-Protocols/corePKCS11"]
 	path = FreeRTOS-Plus/Source/corePKCS11
 	url = https://github.com/FreeRTOS/corePKCS11.git
+[submodule "FreeRTOS-Plus/Source/AWS/jobs"]
+	path = FreeRTOS-Plus/Source/AWS/jobs
+	url = https://github.com/aws/jobs-for-aws-iot-embedded-sdk.git

--- a/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/DemoTasks/ShadowDemoMainExample.c
+++ b/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/DemoTasks/ShadowDemoMainExample.c
@@ -532,7 +532,7 @@ void vStartShadowDemo( void )
      * use Device Shadow library to get shadow topics and validate shadow topics
      * via MQTT APIs communicating with the MQTT broker. */
     xTaskCreate( prvShadowDemoTask,        /* Function that implements the task. */
-                 "ShadowDemo",             /* Text name for the task - only used for debugging. */
+                 "DemoTask",               /* Text name for the task - only used for debugging. */
                  democonfigDEMO_STACKSIZE, /* Size of stack (in words, not bytes) to allocate for the task. */
                  NULL,                     /* Task parameter - not used in this case. */
                  tskIDLE_PRIORITY,         /* Task priority, must be between 0 and configMAX_PRIORITIES - 1. */

--- a/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/DemoTasks/ShadowDemoMainExample.c
+++ b/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/DemoTasks/ShadowDemoMainExample.c
@@ -62,10 +62,10 @@
 /* JSON library includes. */
 #include "core_json.h"
 
-/* Shadow demo helpers header. */
-#include "shadow_demo_helpers.h"
+/* Include MQTT demo helpers header. */
+#include "mqtt_demo_helpers.h"
 
-/* Demo Specific configs. */
+/* Demo Specific config file. */
 #include "demo_config.h"
 
 
@@ -148,24 +148,42 @@
  */
 #define SHADOW_REPORTED_JSON_LENGTH    ( sizeof( SHADOW_REPORTED_JSON ) - 3 )
 
-#ifndef THING_NAME
+/*------------- Demo configurations -------------------------*/
 
-/**
- * @brief Predefined thing name.
- *
- * This is the example predefine thing name and could be compiled in ROM code.
- */
-    #define THING_NAME    democonfigCLIENT_IDENTIFIER
+#ifndef democonfigTHING_NAME
+    #define democonfigTHING_NAME    democonfigCLIENT_IDENTIFIER
 #endif
 
 /**
- * @brief The length of #THING_NAME.
+ * @brief The length of #democonfigTHING_NAME.
  */
-#define THING_NAME_LENGTH    ( ( uint16_t ) ( sizeof( THING_NAME ) - 1 ) )
-
-
+#define THING_NAME_LENGTH    ( ( uint16_t ) ( sizeof( democonfigTHING_NAME ) - 1 ) )
 
 /*-----------------------------------------------------------*/
+
+/**
+ * @brief The MQTT context used for MQTT operation.
+ */
+static MQTTContext_t xMqttContext;
+
+/**
+ * @brief The network context used for mbedTLS operation.
+ */
+static NetworkContext_t xNetworkContext;
+
+/**
+ * @brief Static buffer used to hold MQTT messages being sent and received.
+ */
+static uint8_t ucSharedBuffer[ democonfigNETWORK_BUFFER_SIZE ];
+
+/**
+ * @brief Static buffer used to hold MQTT messages being sent and received.
+ */
+static MQTTFixedBuffer_t xBuffer =
+{
+    .pBuffer = ucSharedBuffer,
+    .size    = democonfigNETWORK_BUFFER_SIZE
+};
 
 /**
  * @brief The simulated device current power on state.
@@ -523,14 +541,15 @@ static void prvEventCallback( MQTTContext_t * pxMqttContext,
 /*-----------------------------------------------------------*/
 
 /*
- * @brief Create the task that demonstrates the Shadow API Demo via a
- * MQTT mutually authenticated network connection with MQTT broker.
+ * @brief Create the task that demonstrates the Device Shadow library API via a
+ * MQTT mutually authenticated network connection with the AWS IoT broker.
  */
 void vStartShadowDemo( void )
 {
     /* This example uses a single application task, which shows that how to
-     * use Device Shadow library to get shadow topics and validate shadow topics
-     * via MQTT APIs communicating with the MQTT broker. */
+     * use Device Shadow library to generate and validate AWS IoT Device Shadow
+     * MQTT topics, and use the coreMQTT library to communicate with the AWS IoT
+     * Device Shadow service. */
     xTaskCreate( prvShadowDemoTask,        /* Function that implements the task. */
                  "DemoTask",               /* Text name for the task - only used for debugging. */
                  democonfigDEMO_STACKSIZE, /* Size of stack (in words, not bytes) to allocate for the task. */
@@ -538,7 +557,6 @@ void vStartShadowDemo( void )
                  tskIDLE_PRIORITY,         /* Task priority, must be between 0 and configMAX_PRIORITIES - 1. */
                  NULL );                   /* Used to pass out a handle to the created task - not used in this case. */
 }
-
 /*-----------------------------------------------------------*/
 
 /**
@@ -564,14 +582,17 @@ void prvShadowDemoTask( void * pvParameters )
 {
     BaseType_t demoStatus = pdPASS;
 
-    /* Remove compiler warnings about unused parameters. */
-    ( void ) pvParameters;
-
     /* A buffer containing the update document. It has static duration to prevent
      * it from being placed on the call stack. */
     static char pcUpdateDocument[ SHADOW_REPORTED_JSON_LENGTH + 1 ] = { 0 };
 
-    demoStatus = xEstablishMqttSession( prvEventCallback );
+    /* Remove compiler warnings about unused parameters. */
+    ( void ) pvParameters;
+
+    demoStatus = xEstablishMqttSession( &xMqttContext,
+                                        &xNetworkContext,
+                                        &xBuffer,
+                                        prvEventCallback );
 
     if( pdFAIL == demoStatus )
     {
@@ -581,7 +602,8 @@ void prvShadowDemoTask( void * pvParameters )
     else
     {
         /* First of all, try to delete any Shadow document in the cloud. */
-        demoStatus = xPublishToTopic( SHADOW_TOPIC_STRING_DELETE( THING_NAME ),
+        demoStatus = xPublishToTopic( &xMqttContext,
+                                      SHADOW_TOPIC_STRING_DELETE( democonfigTHING_NAME ),
                                       SHADOW_TOPIC_LENGTH_DELETE( THING_NAME_LENGTH ),
                                       pcUpdateDocument,
                                       0U );
@@ -589,23 +611,26 @@ void prvShadowDemoTask( void * pvParameters )
         /* Then try to subscribe shadow topics. */
         if( demoStatus == pdPASS )
         {
-            demoStatus = xSubscribeToTopic( SHADOW_TOPIC_STRING_UPDATE_DELTA( THING_NAME ),
+            demoStatus = xSubscribeToTopic( &xMqttContext,
+                                            SHADOW_TOPIC_STRING_UPDATE_DELTA( democonfigTHING_NAME ),
                                             SHADOW_TOPIC_LENGTH_UPDATE_DELTA( THING_NAME_LENGTH ) );
         }
 
         if( demoStatus == pdPASS )
         {
-            demoStatus = xSubscribeToTopic( SHADOW_TOPIC_STRING_UPDATE_ACCEPTED( THING_NAME ),
+            demoStatus = xSubscribeToTopic( &xMqttContext,
+                                            SHADOW_TOPIC_STRING_UPDATE_ACCEPTED( democonfigTHING_NAME ),
                                             SHADOW_TOPIC_LENGTH_UPDATE_ACCEPTED( THING_NAME_LENGTH ) );
         }
 
         if( demoStatus == pdPASS )
         {
-            demoStatus = xSubscribeToTopic( SHADOW_TOPIC_STRING_UPDATE_REJECTED( THING_NAME ),
+            demoStatus = xSubscribeToTopic( &xMqttContext,
+                                            SHADOW_TOPIC_STRING_UPDATE_REJECTED( democonfigTHING_NAME ),
                                             SHADOW_TOPIC_LENGTH_UPDATE_REJECTED( THING_NAME_LENGTH ) );
         }
 
-        /* This demo uses a constant #THING_NAME known at compile time therefore we can use macros to
+        /* This demo uses a constant #democonfigTHING_NAME known at compile time therefore we can use macros to
          * assemble shadow topic strings.
          * If the thing name is known at run time, then we could use the API #Shadow_GetTopicString to
          * assemble shadow topic strings, here is the example for /update/delta:
@@ -651,7 +676,8 @@ void prvShadowDemoTask( void * pvParameters )
                       ( int ) 1,
                       ( long unsigned ) ( xTaskGetTickCount() % 1000000 ) );
 
-            demoStatus = xPublishToTopic( SHADOW_TOPIC_STRING_UPDATE( THING_NAME ),
+            demoStatus = xPublishToTopic( &xMqttContext,
+                                          SHADOW_TOPIC_STRING_UPDATE( democonfigTHING_NAME ),
                                           SHADOW_TOPIC_LENGTH_UPDATE( THING_NAME_LENGTH ),
                                           pcUpdateDocument,
                                           ( SHADOW_DESIRED_JSON_LENGTH + 1 ) );
@@ -683,7 +709,8 @@ void prvShadowDemoTask( void * pvParameters )
                           ( int ) ulCurrentPowerOnState,
                           ( long unsigned ) ulClientToken );
 
-                demoStatus = xPublishToTopic( SHADOW_TOPIC_STRING_UPDATE( THING_NAME ),
+                demoStatus = xPublishToTopic( &xMqttContext,
+                                              SHADOW_TOPIC_STRING_UPDATE( democonfigTHING_NAME ),
                                               SHADOW_TOPIC_LENGTH_UPDATE( THING_NAME_LENGTH ),
                                               pcUpdateDocument,
                                               ( SHADOW_DESIRED_JSON_LENGTH + 1 ) );
@@ -698,42 +725,45 @@ void prvShadowDemoTask( void * pvParameters )
         {
             LogInfo( ( "Start to unsubscribe shadow topics and disconnect from MQTT. \r\n" ) );
 
-            demoStatus = xUnsubscribeFromTopic( SHADOW_TOPIC_STRING_UPDATE_DELTA( THING_NAME ),
+            demoStatus = xUnsubscribeFromTopic( &xMqttContext,
+                                                SHADOW_TOPIC_STRING_UPDATE_DELTA( democonfigTHING_NAME ),
                                                 SHADOW_TOPIC_LENGTH_UPDATE_DELTA( THING_NAME_LENGTH ) );
 
             if( demoStatus != pdPASS )
             {
                 LogError( ( "Failed to unsubscribe the topic %s",
-                            SHADOW_TOPIC_STRING_UPDATE_DELTA( THING_NAME ) ) );
+                            SHADOW_TOPIC_STRING_UPDATE_DELTA( democonfigTHING_NAME ) ) );
             }
         }
 
         if( demoStatus == pdPASS )
         {
-            demoStatus = xUnsubscribeFromTopic( SHADOW_TOPIC_STRING_UPDATE_ACCEPTED( THING_NAME ),
+            demoStatus = xUnsubscribeFromTopic( &xMqttContext,
+                                                SHADOW_TOPIC_STRING_UPDATE_ACCEPTED( democonfigTHING_NAME ),
                                                 SHADOW_TOPIC_LENGTH_UPDATE_ACCEPTED( THING_NAME_LENGTH ) );
 
             if( demoStatus != pdPASS )
             {
                 LogError( ( "Failed to unsubscribe the topic %s",
-                            SHADOW_TOPIC_STRING_UPDATE_ACCEPTED( THING_NAME ) ) );
+                            SHADOW_TOPIC_STRING_UPDATE_ACCEPTED( democonfigTHING_NAME ) ) );
             }
         }
 
         if( demoStatus == pdPASS )
         {
-            demoStatus = xUnsubscribeFromTopic( SHADOW_TOPIC_STRING_UPDATE_REJECTED( THING_NAME ),
+            demoStatus = xUnsubscribeFromTopic( &xMqttContext,
+                                                SHADOW_TOPIC_STRING_UPDATE_REJECTED( democonfigTHING_NAME ),
                                                 SHADOW_TOPIC_LENGTH_UPDATE_REJECTED( THING_NAME_LENGTH ) );
 
             if( demoStatus != pdPASS )
             {
                 LogError( ( "Failed to unsubscribe the topic %s",
-                            SHADOW_TOPIC_STRING_UPDATE_REJECTED( THING_NAME ) ) );
+                            SHADOW_TOPIC_STRING_UPDATE_REJECTED( democonfigTHING_NAME ) ) );
             }
         }
 
         /* The MQTT session is always disconnected, even there were prior failures. */
-        demoStatus = xDisconnectMqttSession();
+        demoStatus = xDisconnectMqttSession( &xMqttContext, &xNetworkContext );
 
         /* This demo performs only Device Shadow operations. If matching the Shadow
          * MQTT topic fails or there are failure in parsing the received JSON document,

--- a/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/DemoTasks/shadow_demo_helpers.c
+++ b/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/DemoTasks/shadow_demo_helpers.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS V202010.00
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/DemoTasks/shadow_demo_helpers.h
+++ b/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/DemoTasks/shadow_demo_helpers.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS V202010.00
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/READ_ME_INSTRUCTIONS.url
+++ b/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/READ_ME_INSTRUCTIONS.url
@@ -2,4 +2,5 @@
 Prop3=19,11
 [InternetShortcut]
 IDList=
-URL=https://www.freertos.org/shadow/index.html
+URL=https://www.freertos.org/iot-device-shadow/index.html
+

--- a/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/WIN32.vcxproj
+++ b/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/WIN32.vcxproj
@@ -58,7 +58,7 @@
     </Midl>
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\..\..\..\..\Source\FreeRTOS-Plus-Trace\Include;..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include;..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\BufferManagement;..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\Compiler\MSVC;..\..\..\..\..\FreeRTOS-Plus\Source\Utilities\logging;..\common\WinPCap;..\..\..\..\..\FreeRTOS\Source\include;..\..\..\..\..\FreeRTOS\Source\portable\MSVC-MingW;..\..\..\..\Source\Application-Protocols\coreMQTT\source\include;..\..\..\..\Source\Application-Protocols\coreMQTT\source\interface;..\..\..\..\Source\Utilities\exponential_backoff;..\..\..\..\Source\Application-Protocols\network_transport\freertos_plus_tcp;..\..\..\..\Source\Application-Protocols\network_transport\freertos_plus_tcp\using_mbedtls;..\..\..\..\Source\Utilities\mbedtls_freertos;..\..\..\..\..\Source\mbedtls_utils;..\..\..\..\ThirdParty\mbedtls\include;..\..\..\..\Source\AWS\device-shadow\source\include;..\..\..\..\Source\coreJSON\source\include;.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\..\..\Source\FreeRTOS-Plus-Trace\Include;..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include;..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\BufferManagement;..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\Compiler\MSVC;..\..\..\..\..\FreeRTOS-Plus\Source\Utilities\logging;..\common\WinPCap;..\..\..\..\..\FreeRTOS\Source\include;..\..\..\..\..\FreeRTOS\Source\portable\MSVC-MingW;..\..\..\..\Source\Application-Protocols\coreMQTT\source\include;..\..\..\..\Source\Application-Protocols\coreMQTT\source\interface;..\..\..\..\Source\Utilities\exponential_backoff;..\..\..\..\Source\Application-Protocols\network_transport\freertos_plus_tcp;..\..\..\..\Source\Application-Protocols\network_transport\freertos_plus_tcp\using_mbedtls;..\..\..\..\Source\Utilities\mbedtls_freertos;..\..\..\..\..\Source\mbedtls_utils;..\..\..\..\ThirdParty\mbedtls\include;..\..\..\..\Source\AWS\device-shadow\source\include;..\..\..\..\Source\coreJSON\source\include;..\..\Mqtt_Demo_Helpers;.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>MBEDTLS_CONFIG_FILE="mbedtls_config.h";WIN32;_DEBUG;_CONSOLE;_WIN32_WINNT=0x0500;WINVER=0x400;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -490,7 +490,7 @@
     <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Demo\Common\Logging\windows\Logging_WinSim.c" />
     <ClCompile Include="..\Common\main.c" />
     <ClCompile Include="DemoTasks\ShadowDemoMainExample.c" />
-    <ClCompile Include="DemoTasks\shadow_demo_helpers.c" />
+    <ClCompile Include="..\..\Mqtt_Demo_Helpers\mqtt_demo_helpers.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\..\..\FreeRTOS\Source\include\event_groups.h" />

--- a/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/core_mqtt_config.h
+++ b/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/core_mqtt_config.h
@@ -56,7 +56,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Map the SdkLog macro to the logging function to enable logging
  * on Windows simulator. */
-#define SdkLog( message )    vLoggingPrintf message
+#ifndef SdkLog
+    #define SdkLog( message )    vLoggingPrintf message
+#endif
 
 #include "logging_stack.h"
 /************ End of logging configuration ****************/

--- a/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/core_mqtt_config.h
+++ b/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/core_mqtt_config.h
@@ -47,6 +47,17 @@
     #define LIBRARY_LOG_LEVEL    LOG_ERROR
 #endif
 
+/* Prototype for the function used to print to console on Windows simulator
+ * of FreeRTOS.
+ * The function prints to the console before the network is connected;
+ * then a UDP port after the network has connected. */
+extern void vLoggingPrintf( const char * pcFormatString,
+                            ... );
+
+/* Map the SdkLog macro to the logging function to enable logging
+ * on Windows simulator. */
+#define SdkLog( message )    vLoggingPrintf message
+
 #include "logging_stack.h"
 /************ End of logging configuration ****************/
 

--- a/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/demo_config.h
+++ b/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/demo_config.h
@@ -61,7 +61,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Map the SdkLog macro to the logging function to enable logging
  * on Windows simulator. */
-#define SdkLog( message )    vLoggingPrintf message
+#ifndef SdkLog
+    #define SdkLog( message )    vLoggingPrintf message
+#endif
 
 #include "logging_stack.h"
 

--- a/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/demo_config.h
+++ b/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/demo_config.h
@@ -51,11 +51,24 @@
 #ifndef LIBRARY_LOG_LEVEL
     #define LIBRARY_LOG_LEVEL    LOG_INFO
 #endif
+
+/* Prototype for the function used to print to console on Windows simulator
+ * of FreeRTOS.
+ * The function prints to the console before the network is connected;
+ * then a UDP port after the network has connected. */
+extern void vLoggingPrintf( const char * pcFormatString,
+                            ... );
+
+/* Map the SdkLog macro to the logging function to enable logging
+ * on Windows simulator. */
+#define SdkLog( message )    vLoggingPrintf message
+
 #include "logging_stack.h"
 
 /************ End of logging configuration ****************/
 
 #ifndef democonfigCLIENT_IDENTIFIER
+
 /**
  * @brief The MQTT client identifier used in this example.  Each client identifier
  * must be unique so edit as required to ensure no two clients connecting to the
@@ -114,27 +127,27 @@
  * #define democonfigROOT_CA_PEM    "...insert here..."
  */
 
-#define democonfigROOT_CA_PEM \
-"-----BEGIN CERTIFICATE-----\n"\
-"MIIDQTCCAimgAwIBAgITBmyfz5m/jAo54vB4ikPmljZbyjANBgkqhkiG9w0BAQsF\n"\
-"ADA5MQswCQYDVQQGEwJVUzEPMA0GA1UEChMGQW1hem9uMRkwFwYDVQQDExBBbWF6\n"\
-"b24gUm9vdCBDQSAxMB4XDTE1MDUyNjAwMDAwMFoXDTM4MDExNzAwMDAwMFowOTEL\n"\
-"MAkGA1UEBhMCVVMxDzANBgNVBAoTBkFtYXpvbjEZMBcGA1UEAxMQQW1hem9uIFJv\n"\
-"b3QgQ0EgMTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALJ4gHHKeNXj\n"\
-"ca9HgFB0fW7Y14h29Jlo91ghYPl0hAEvrAIthtOgQ3pOsqTQNroBvo3bSMgHFzZM\n"\
-"9O6II8c+6zf1tRn4SWiw3te5djgdYZ6k/oI2peVKVuRF4fn9tBb6dNqcmzU5L/qw\n"\
-"IFAGbHrQgLKm+a/sRxmPUDgH3KKHOVj4utWp+UhnMJbulHheb4mjUcAwhmahRWa6\n"\
-"VOujw5H5SNz/0egwLX0tdHA114gk957EWW67c4cX8jJGKLhD+rcdqsq08p8kDi1L\n"\
-"93FcXmn/6pUCyziKrlA4b9v7LWIbxcceVOF34GfID5yHI9Y/QCB/IIDEgEw+OyQm\n"\
-"jgSubJrIqg0CAwEAAaNCMEAwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMC\n"\
-"AYYwHQYDVR0OBBYEFIQYzIU07LwMlJQuCFmcx7IQTgoIMA0GCSqGSIb3DQEBCwUA\n"\
-"A4IBAQCY8jdaQZChGsV2USggNiMOruYou6r4lK5IpDB/G/wkjUu0yKGX9rbxenDI\n"\
-"U5PMCCjjmCXPI6T53iHTfIUJrU6adTrCC2qJeHZERxhlbI1Bjjt/msv0tadQ1wUs\n"\
-"N+gDS63pYaACbvXy8MWy7Vu33PqUXHeeE6V/Uq2V8viTO96LXFvKWlJbYK8U90vv\n"\
-"o/ufQJVtMVT8QtPHRh8jrdkPSHCa2XV4cdFyQzR1bldZwgJcJmApzyMZFo6IQ6XU\n"\
-"5MsI+yMRQ+hDKXJioaldXgjUkK642M4UwtBV8ob2xJNDd2ZhwLnoQdeXeGADbkpy\n"\
-"rqXRfboQnoZsG4q5WTP468SQvvG5\n"\
-"-----END CERTIFICATE-----"
+#define democonfigROOT_CA_PEM                                            \
+    "-----BEGIN CERTIFICATE-----\n"                                      \
+    "MIIDQTCCAimgAwIBAgITBmyfz5m/jAo54vB4ikPmljZbyjANBgkqhkiG9w0BAQsF\n" \
+    "ADA5MQswCQYDVQQGEwJVUzEPMA0GA1UEChMGQW1hem9uMRkwFwYDVQQDExBBbWF6\n" \
+    "b24gUm9vdCBDQSAxMB4XDTE1MDUyNjAwMDAwMFoXDTM4MDExNzAwMDAwMFowOTEL\n" \
+    "MAkGA1UEBhMCVVMxDzANBgNVBAoTBkFtYXpvbjEZMBcGA1UEAxMQQW1hem9uIFJv\n" \
+    "b3QgQ0EgMTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALJ4gHHKeNXj\n" \
+    "ca9HgFB0fW7Y14h29Jlo91ghYPl0hAEvrAIthtOgQ3pOsqTQNroBvo3bSMgHFzZM\n" \
+    "9O6II8c+6zf1tRn4SWiw3te5djgdYZ6k/oI2peVKVuRF4fn9tBb6dNqcmzU5L/qw\n" \
+    "IFAGbHrQgLKm+a/sRxmPUDgH3KKHOVj4utWp+UhnMJbulHheb4mjUcAwhmahRWa6\n" \
+    "VOujw5H5SNz/0egwLX0tdHA114gk957EWW67c4cX8jJGKLhD+rcdqsq08p8kDi1L\n" \
+    "93FcXmn/6pUCyziKrlA4b9v7LWIbxcceVOF34GfID5yHI9Y/QCB/IIDEgEw+OyQm\n" \
+    "jgSubJrIqg0CAwEAAaNCMEAwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMC\n" \
+    "AYYwHQYDVR0OBBYEFIQYzIU07LwMlJQuCFmcx7IQTgoIMA0GCSqGSIb3DQEBCwUA\n" \
+    "A4IBAQCY8jdaQZChGsV2USggNiMOruYou6r4lK5IpDB/G/wkjUu0yKGX9rbxenDI\n" \
+    "U5PMCCjjmCXPI6T53iHTfIUJrU6adTrCC2qJeHZERxhlbI1Bjjt/msv0tadQ1wUs\n" \
+    "N+gDS63pYaACbvXy8MWy7Vu33PqUXHeeE6V/Uq2V8viTO96LXFvKWlJbYK8U90vv\n" \
+    "o/ufQJVtMVT8QtPHRh8jrdkPSHCa2XV4cdFyQzR1bldZwgJcJmApzyMZFo6IQ6XU\n" \
+    "5MsI+yMRQ+hDKXJioaldXgjUkK642M4UwtBV8ob2xJNDd2ZhwLnoQdeXeGADbkpy\n" \
+    "rqXRfboQnoZsG4q5WTP468SQvvG5\n"                                     \
+    "-----END CERTIFICATE-----"
 
 /**
  * @brief Client certificate.

--- a/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/demo_config.h
+++ b/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/demo_config.h
@@ -67,6 +67,17 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /************ End of logging configuration ****************/
 
+/**
+ * @brief The Thing resource registered on your AWS IoT account to use in the demo.
+ * A Thing resource is required to communicate with the AWS IoT Device Shadow service.
+ *
+ * @note The Things associated with your AWS account can be found in the
+ * AWS IoT console under Manage/Things, or using the ListThings REST API (that can
+ * be called with the AWS CLI command line tool).
+ *
+ * #define democonfigTHING_NAME    "...insert here..."
+ */
+
 #ifndef democonfigCLIENT_IDENTIFIER
 
 /**
@@ -83,16 +94,11 @@ extern void vLoggingPrintf( const char * pcFormatString,
 #endif
 
 /**
- * @brief Endpoint of the MQTT broker to connect to.
- *
- * This demo application can be run with any MQTT broker, that supports mutual
- * authentication.
- *
- * For AWS IoT MQTT broker, this is the Thing's REST API Endpoint.
+ * @brief The AWS IoT broker endpoint to connect to in the demo.
  *
  * @note Your AWS IoT Core endpoint can be found in the AWS IoT console under
- * Settings/Custom Endpoint, or using the describe-endpoint REST API (with
- * AWS CLI command line tool).
+ * Settings/Custom Endpoint, or using the DescribeEndpoint REST API (that can
+ * be called with AWS CLI command line tool).
  *
  * #define democonfigMQTT_BROKER_ENDPOINT    "...insert here..."
  */
@@ -113,8 +119,8 @@ extern void vLoggingPrintf( const char * pcFormatString,
 /**
  * @brief AWS root CA certificate.
  *
- * For AWS IoT MQTT broker, this certificate is used to identify the AWS IoT
- * server and is publicly available. Refer to the link below.
+ * This certificate is used to identify the AWS IoT server and is publicly available.
+ * Refer to the link below.
  * https://www.amazontrust.com/repository/AmazonRootCA1.pem
  *
  * @note This certificate should be PEM-encoded.
@@ -124,7 +130,6 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * "...base64 data...\n"\
  * "-----END CERTIFICATE-----\n"
  *
- * #define democonfigROOT_CA_PEM    "...insert here..."
  */
 
 #define democonfigROOT_CA_PEM                                            \
@@ -152,7 +157,7 @@ extern void vLoggingPrintf( const char * pcFormatString,
 /**
  * @brief Client certificate.
  *
- * For AWS IoT MQTT broker, refer to the AWS documentation below for details
+ * Please refer to the AWS documentation below for details
  * regarding client authentication.
  * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
  *
@@ -169,7 +174,7 @@ extern void vLoggingPrintf( const char * pcFormatString,
 /**
  * @brief Client's private key.
  *
- * For AWS IoT MQTT broker, refer to the AWS documentation below for details
+ * Please refer to the AWS documentation below for details
  * regarding clientauthentication.
  * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
  *
@@ -187,7 +192,7 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * @brief The username value for authenticating client to the MQTT broker when
  * username/password based client authentication is used.
  *
- * For AWS IoT MQTT broker, refer to the AWS IoT documentation below for
+ * Please refer to the AWS IoT documentation below for
  * details regarding client authentication with a username and password.
  * https://docs.aws.amazon.com/iot/latest/developerguide/custom-authentication.html
  * An authorizer setup needs to be done, as mentioned in the above link, to use
@@ -200,7 +205,7 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * @brief The password value for authenticating client to the MQTT broker when
  * username/password based client authentication is used.
  *
- * For AWS IoT MQTT broker, refer to the AWS IoT documentation below for
+ * Please refer to the AWS IoT documentation below for
  * details regarding client authentication with a username and password.
  * https://docs.aws.amazon.com/iot/latest/developerguide/custom-authentication.html
  * An authorizer setup needs to be done, as mentioned in the above link, to use

--- a/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/shadow_config.h
+++ b/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/shadow_config.h
@@ -53,7 +53,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Map the SdkLog macro to the logging function to enable logging
  * on Windows simulator. */
-#define SdkLog( message )    vLoggingPrintf message
+#ifndef SdkLog
+    #define SdkLog( message )    vLoggingPrintf message
+#endif
 
 #include "logging_stack.h"
 

--- a/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/shadow_config.h
+++ b/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/shadow_config.h
@@ -44,6 +44,17 @@
     #define LIBRARY_LOG_LEVEL    LOG_INFO
 #endif
 
+/* Prototype for the function used to print to console on Windows simulator
+ * of FreeRTOS.
+ * The function prints to the console before the network is connected;
+ * then a UDP port after the network has connected. */
+extern void vLoggingPrintf( const char * pcFormatString,
+                            ... );
+
+/* Map the SdkLog macro to the logging function to enable logging
+ * on Windows simulator. */
+#define SdkLog( message )    vLoggingPrintf message
+
 #include "logging_stack.h"
 
 /************ End of logging configuration ****************/

--- a/FreeRTOS-Plus/Demo/AWS/Mqtt_Demo_Helpers/mqtt_demo_helpers.h
+++ b/FreeRTOS-Plus/Demo/AWS/Mqtt_Demo_Helpers/mqtt_demo_helpers.h
@@ -20,8 +20,8 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#ifndef SHADOW_DEMO_HELPERS_H
-#define SHADOW_DEMO_HELPERS_H
+#ifndef MQTT_DEMO_HELPERS_H
+#define MQTT_DEMO_HELPERS_H
 
 /* MQTT API header. */
 #include "core_mqtt.h"
@@ -29,17 +29,24 @@
 /* Transport interface implementation include header for TLS. */
 #include "using_mbedtls.h"
 
-/*-----------------------------------------------------------*/
-
 /**
  * @brief Establish a MQTT connection.
  *
- * @param[in] eventCallback The callback function used to receive incoming
+ * @param[in, out] pxMqttContext The memory for the MQTTContext_t that will be used for the
+ * MQTT connection.
+ * @param[out] pxNetworkContext The memory for the NetworkContext_t required for the
+ * MQTT connection.
+ * @param[in] pxNetworkBuffer The buffer space for initializing the @p pxMqttContext MQTT
+ * context used in the MQTT connection.
+ * @param[in] appCallback The callback function used to receive incoming
  * publishes and incoming acks from MQTT library.
  *
  * @return The status of the final connection attempt.
  */
-BaseType_t xEstablishMqttSession( MQTTEventCallback_t eventCallback );
+BaseType_t xEstablishMqttSession( MQTTContext_t * pxMqttContext,
+                                  NetworkContext_t * pxNetworkContext,
+                                  MQTTFixedBuffer_t * pxNetworkBuffer,
+                                  MQTTEventCallback_t eventCallback );
 
 /**
  * @brief Handle the incoming packet if it's not related to the device shadow.
@@ -53,41 +60,50 @@ void vHandleOtherIncomingPacket( MQTTPacketInfo_t * pxPacketInfo,
 /**
  * @brief Close the MQTT connection.
  *
+ * @param[in, out] pxMqttContext The MQTT context for the MQTT connection to close.
+ * @param[in, out] pxNetworkContext The network context for the TLS session to
+ * terminate.
+ *
  * @return pdPASS if DISCONNECT was successfully sent;
  * pdFAIL otherwise.
  */
-BaseType_t xDisconnectMqttSession( void );
+BaseType_t xDisconnectMqttSession( MQTTContext_t * pxMqttContext,
+                                   NetworkContext_t * pxNetworkContext );
 
 /**
  * @brief Subscribe to a MQTT topic filter.
  *
+ * @param[in] pxMqttContext The MQTT context for the MQTT connection to close.
  * @param[in] pcTopicFilter Pointer to the shadow topic buffer.
  * @param[in] usTopicFilterLength Indicates the length of the shadow
- * topic filter.
+ * topic buffer.
  *
  * @return pdPASS if SUBSCRIBE was successfully sent;
  * pdFAIL otherwise.
  */
-BaseType_t xSubscribeToTopic( const char * pcTopicFilter,
+BaseType_t xSubscribeToTopic( MQTTContext_t * pxMqttContext,
+                              const char * pcTopicFilter,
                               uint16_t usTopicFilterLength );
 
 /**
  * @brief Sends an MQTT UNSUBSCRIBE to unsubscribe from the shadow
  * topic.
  *
- * @param[in] pcTopicFilter Pointer to the shadow topic buffer.
- * @param[in] usTopicFilterLength Indicates the length of the shadow
- * topic filter.
+ * @param[in] pxMqttContext The MQTT context for the MQTT connection.
+ * @param[in] pcTopicFilter Pointer to the MQTT topic filter.
+ * @param[in] usTopicFilterLength Indicates the length of the topic filter.
  *
  * @return pdPASS if UNSUBSCRIBE was successfully sent;
  * pdFAIL otherwise.
  */
-BaseType_t xUnsubscribeFromTopic( const char * pcTopicFilter,
+BaseType_t xUnsubscribeFromTopic( MQTTContext_t * pxMqttContext,
+                                  const char * pcTopicFilter,
                                   uint16_t usTopicFilterLength );
 
 /**
  * @brief Publish a message to a MQTT topic.
  *
+ * @param[in] pxMqttContext The MQTT context for the MQTT connection.
  * @param[in] pcTopicFilter Points to the topic.
  * @param[in] topicFilterLength The length of the topic.
  * @param[in] pcPayload Points to the payload.
@@ -96,9 +112,10 @@ BaseType_t xUnsubscribeFromTopic( const char * pcTopicFilter,
  * @return pdPASS if PUBLISH was successfully sent;
  * pdFAIL otherwise.
  */
-BaseType_t xPublishToTopic( const char * pcTopicFilter,
+BaseType_t xPublishToTopic( MQTTContext_t * pxMqttContext,
+                            const char * pcTopicFilter,
                             int32_t topicFilterLength,
                             const char * pcPayload,
                             size_t payloadLength );
 
-#endif /* ifndef SHADOW_DEMO_HELPERS_H */
+#endif /* ifndef MQTT_DEMO_HELPERS_H */

--- a/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_CLI_Demos/File-Related-CLI-commands.c
+++ b/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_CLI_Demos/File-Related-CLI-commands.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_CLI_Demos/Sample-CLI-commands.c
+++ b/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_CLI_Demos/Sample-CLI-commands.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_CLI_Demos/UARTCommandConsole.c
+++ b/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_CLI_Demos/UARTCommandConsole.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_CLI_Demos/UDP-Related-CLI-commands.c
+++ b/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_CLI_Demos/UDP-Related-CLI-commands.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_FAT_SL_Demos/CreateExampleFiles/File-system-demo.c
+++ b/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_FAT_SL_Demos/CreateExampleFiles/File-system-demo.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_UDP_Demos/CLICommands/CLI-commands.c
+++ b/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_UDP_Demos/CLICommands/CLI-commands.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_UDP_Demos/CLICommands/UDPCommandInterpreter.h
+++ b/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_UDP_Demos/CLICommands/UDPCommandInterpreter.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_UDP_Demos/CLICommands/UDPCommandServer.c
+++ b/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_UDP_Demos/CLICommands/UDPCommandServer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_UDP_Demos/EchoClients/TwoEchoClients.c
+++ b/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_UDP_Demos/EchoClients/TwoEchoClients.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_UDP_Demos/EchoClients/TwoEchoClients.h
+++ b/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_UDP_Demos/EchoClients/TwoEchoClients.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_UDP_Demos/TraceMacros/Example1/DemoIPTrace.c
+++ b/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_UDP_Demos/TraceMacros/Example1/DemoIPTrace.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_UDP_Demos/TraceMacros/Example1/DemoIPTrace.h
+++ b/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_UDP_Demos/TraceMacros/Example1/DemoIPTrace.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/Common/Logging/windows/Logging_WinSim.c
+++ b/FreeRTOS-Plus/Demo/Common/Logging/windows/Logging_WinSim.c
@@ -263,6 +263,7 @@ void vLoggingPrintf( const char * pcFormat,
     char * pcSource, * pcTarget, * pcBegin;
     size_t xLength, xLength2, rc;
     static BaseType_t xMessageNumber = 0;
+    static BaseType_t xAfterLineBreak = pdTRUE;
     va_list args;
     uint32_t ulIPAddress;
     const char * pcTaskName;
@@ -286,17 +287,19 @@ void vLoggingPrintf( const char * pcFormat,
             pcTaskName = pcNoTask;
         }
 
-        if( strcmp( pcFormat, "\r\n" ) != 0 )
+        if( ( xAfterLineBreak == pdTRUE ) && ( strcmp( pcFormat, "\r\n" ) != 0 ) )
         {
             xLength = snprintf( cPrintString, dlMAX_PRINT_STRING_LENGTH, "%lu %lu [%s] ",
                                 xMessageNumber++,
                                 ( unsigned long ) xTaskGetTickCount(),
                                 pcTaskName );
+            xAfterLineBreak = pdFALSE;
         }
         else
         {
             xLength = 0;
             memset( cPrintString, 0x00, dlMAX_PRINT_STRING_LENGTH );
+            xAfterLineBreak = pdTRUE;
         }
 
         xLength2 = vsnprintf( cPrintString + xLength, dlMAX_PRINT_STRING_LENGTH - xLength, pcFormat, args );

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_CLI_with_Trace_Windows_Simulator/CLI-commands.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_CLI_with_Trace_Windows_Simulator/CLI-commands.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_CLI_with_Trace_Windows_Simulator/FreeRTOSConfig.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_CLI_with_Trace_Windows_Simulator/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_CLI_with_Trace_Windows_Simulator/Run-time-stats-utils.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_CLI_with_Trace_Windows_Simulator/Run-time-stats-utils.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_CLI_with_Trace_Windows_Simulator/UDPCommandServer.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_CLI_with_Trace_Windows_Simulator/UDPCommandServer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_CLI_with_Trace_Windows_Simulator/main.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_CLI_with_Trace_Windows_Simulator/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_Reliance_Edge_and_CLI_Windows_Simulator/ConfigurationFiles/FreeRTOSConfig.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_Reliance_Edge_and_CLI_Windows_Simulator/ConfigurationFiles/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_Reliance_Edge_and_CLI_Windows_Simulator/File-Related-CLI-commands.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_Reliance_Edge_and_CLI_Windows_Simulator/File-Related-CLI-commands.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_Reliance_Edge_and_CLI_Windows_Simulator/File-system-demo.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_Reliance_Edge_and_CLI_Windows_Simulator/File-system-demo.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_Reliance_Edge_and_CLI_Windows_Simulator/Run-time-stats-utils.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_Reliance_Edge_and_CLI_Windows_Simulator/Run-time-stats-utils.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_Reliance_Edge_and_CLI_Windows_Simulator/Sample-CLI-commands.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_Reliance_Edge_and_CLI_Windows_Simulator/Sample-CLI-commands.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_Reliance_Edge_and_CLI_Windows_Simulator/UDPCommandServer.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_Reliance_Edge_and_CLI_Windows_Simulator/UDPCommandServer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_Reliance_Edge_and_CLI_Windows_Simulator/main.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_Reliance_Edge_and_CLI_Windows_Simulator/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/DemoTasks/SimpleUDPClientAndServer.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/DemoTasks/SimpleUDPClientAndServer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/DemoTasks/TCPEchoClient_SingleTasks.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/DemoTasks/TCPEchoClient_SingleTasks.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/DemoTasks/include/SimpleUDPClientAndServer.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/DemoTasks/include/SimpleUDPClientAndServer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/DemoTasks/include/TCPEchoClient_SingleTasks.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/DemoTasks/include/TCPEchoClient_SingleTasks.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/FreeRTOSConfig.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/FreeRTOSIPConfig.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/FreeRTOSIPConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/WinPCap/arch.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/WinPCap/arch.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/WinPCap/netif.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/WinPCap/netif.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/main.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_WolfSSL_FIPS_Ready_Windows_Simulator/FreeRTOSConfig.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_WolfSSL_FIPS_Ready_Windows_Simulator/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_WolfSSL_FIPS_Ready_Windows_Simulator/SecureTCPClientTask.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_WolfSSL_FIPS_Ready_Windows_Simulator/SecureTCPClientTask.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_WolfSSL_FIPS_Ready_Windows_Simulator/SecureTCPServerTask.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_WolfSSL_FIPS_Ready_Windows_Simulator/SecureTCPServerTask.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_WolfSSL_FIPS_Ready_Windows_Simulator/main.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_WolfSSL_FIPS_Ready_Windows_Simulator/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_WolfSSL_Windows_Simulator/FreeRTOSConfig.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_WolfSSL_Windows_Simulator/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_WolfSSL_Windows_Simulator/SecureTCPClientTask.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_WolfSSL_Windows_Simulator/SecureTCPClientTask.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_WolfSSL_Windows_Simulator/SecureTCPServerTask.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_WolfSSL_Windows_Simulator/SecureTCPServerTask.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_WolfSSL_Windows_Simulator/main.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_WolfSSL_Windows_Simulator/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/DemoTasks/BasicTLSMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/DemoTasks/BasicTLSMQTTExample.c
@@ -343,7 +343,7 @@ void vStartSimpleMQTTDemo( void )
      * connect, subscribe, publish, unsubscribe, and disconnect from the MQTT
      * broker. */
     xTaskCreate( prvMQTTDemoTask,          /* Function that implements the task. */
-                 "MQTTDemo",               /* Text name for the task - only used for debugging. */
+                 "DemoTask",               /* Text name for the task - only used for debugging. */
                  democonfigDEMO_STACKSIZE, /* Size of stack (in words, not bytes) to allocate for the task. */
                  NULL,                     /* Task parameter - not used in this case. */
                  tskIDLE_PRIORITY,         /* Task priority, must be between 0 and configMAX_PRIORITIES - 1. */

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/core_mqtt_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/core_mqtt_config.h
@@ -56,7 +56,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Map the SdkLog macro to the logging function to enable logging
  * on Windows simulator. */
-#define SdkLog( message )    vLoggingPrintf message
+#ifndef SdkLog
+    #define SdkLog( message )    vLoggingPrintf message
+#endif
 
 #include "logging_stack.h"
 /************ End of logging configuration ****************/

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/core_mqtt_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/core_mqtt_config.h
@@ -47,6 +47,17 @@
     #define LIBRARY_LOG_LEVEL    LOG_ERROR
 #endif
 
+/* Prototype for the function used to print to console on Windows simulator
+ * of FreeRTOS.
+ * The function prints to the console before the network is connected;
+ * then a UDP port after the network has connected. */
+extern void vLoggingPrintf( const char * pcFormatString,
+                            ... );
+
+/* Map the SdkLog macro to the logging function to enable logging
+ * on Windows simulator. */
+#define SdkLog( message )    vLoggingPrintf message
+
 #include "logging_stack.h"
 /************ End of logging configuration ****************/
 

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/demo_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/demo_config.h
@@ -61,7 +61,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Map the SdkLog macro to the logging function to enable logging
  * on Windows simulator. */
-#define SdkLog( message )    vLoggingPrintf message
+#ifndef SdkLog
+    #define SdkLog( message )    vLoggingPrintf message
+#endif
 
 #include "logging_stack.h"
 

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/demo_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/demo_config.h
@@ -51,6 +51,18 @@
 #ifndef LIBRARY_LOG_LEVEL
     #define LIBRARY_LOG_LEVEL    LOG_INFO
 #endif
+
+/* Prototype for the function used to print to console on Windows simulator
+ * of FreeRTOS.
+ * The function prints to the console before the network is connected;
+ * then a UDP port after the network has connected. */
+extern void vLoggingPrintf( const char * pcFormatString,
+                            ... );
+
+/* Map the SdkLog macro to the logging function to enable logging
+ * on Windows simulator. */
+#define SdkLog( message )    vLoggingPrintf message
+
 #include "logging_stack.h"
 
 /************ End of logging configuration ****************/

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/readme.url
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/readme.url
@@ -2,4 +2,4 @@
 Prop3=19,11
 [InternetShortcut]
 IDList=
-URL=https://www.freertos.org/mqtt/index.html
+URL=https://www.freertos.org/mqtt/server-authentication-mqtt-example.html

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Keep_Alive/DemoTasks/KeepAliveMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Keep_Alive/DemoTasks/KeepAliveMQTTExample.c
@@ -441,7 +441,7 @@ void vStartSimpleMQTTDemo( void )
      * connect, subscribe, publish, unsubscribe and disconnect from the MQTT
      * broker. */
     xTaskCreate( prvMQTTDemoTask,          /* Function that implements the task. */
-                 "MQTTDemo",               /* Text name for the task - only used for debugging. */
+                 "DemoTask",               /* Text name for the task - only used for debugging. */
                  democonfigDEMO_STACKSIZE, /* Size of stack (in words, not bytes) to allocate for the task. */
                  NULL,                     /* Task parameter - not used in this case. */
                  tskIDLE_PRIORITY,         /* Task priority, must be between 0 and configMAX_PRIORITIES - 1. */

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Keep_Alive/core_mqtt_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Keep_Alive/core_mqtt_config.h
@@ -58,7 +58,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Map the SdkLog macro to the logging function to enable logging
  * on Windows simulator. */
-#define SdkLog( message )    vLoggingPrintf message
+#ifndef SdkLog
+    #define SdkLog( message )    vLoggingPrintf message
+#endif
 
 #include "logging_stack.h"
 /************ End of logging configuration ****************/

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Keep_Alive/core_mqtt_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Keep_Alive/core_mqtt_config.h
@@ -49,6 +49,17 @@
     #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
+/* Prototype for the function used to print to console on Windows simulator
+ * of FreeRTOS.
+ * The function prints to the console before the network is connected;
+ * then a UDP port after the network has connected. */
+extern void vLoggingPrintf( const char * pcFormatString,
+                            ... );
+
+/* Map the SdkLog macro to the logging function to enable logging
+ * on Windows simulator. */
+#define SdkLog( message )    vLoggingPrintf message
+
 #include "logging_stack.h"
 /************ End of logging configuration ****************/
 

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Keep_Alive/demo_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Keep_Alive/demo_config.h
@@ -59,7 +59,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Map the SdkLog macro to the logging function to enable logging
  * on Windows simulator. */
-#define SdkLog( message )    vLoggingPrintf message
+#ifndef SdkLog
+    #define SdkLog( message )    vLoggingPrintf message
+#endif
 
 #include "logging_stack.h"
 

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Keep_Alive/demo_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Keep_Alive/demo_config.h
@@ -49,6 +49,18 @@
 #ifndef LIBRARY_LOG_LEVEL
     #define LIBRARY_LOG_LEVEL    LOG_INFO
 #endif
+
+/* Prototype for the function used to print to console on Windows simulator
+ * of FreeRTOS.
+ * The function prints to the console before the network is connected;
+ * then a UDP port after the network has connected. */
+extern void vLoggingPrintf( const char * pcFormatString,
+                            ... );
+
+/* Map the SdkLog macro to the logging function to enable logging
+ * on Windows simulator. */
+#define SdkLog( message )    vLoggingPrintf message
+
 #include "logging_stack.h"
 
 /************ End of logging configuration ****************/

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Keep_Alive/readme.url
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Keep_Alive/readme.url
@@ -2,4 +2,4 @@
 Prop3=19,11
 [InternetShortcut]
 IDList=
-URL=https://www.freertos.org/mqtt/index.html
+URL=https://www.freertos.org/mqtt/mqtt-keepalive-demo.html

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Multitask/DemoTasks/MultitaskMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Multitask/DemoTasks/MultitaskMQTTExample.c
@@ -1809,7 +1809,7 @@ void prvAsyncPublishTask( void * pvParameters )
     for( int i = 0; i < mqttexamplePUBLISH_COUNT / 2; i++ )
     {
         pxContexts[ i ] = ( CommandContext_t * ) pvPortMalloc( sizeof( CommandContext_t ) );
-        memset( ( void * ) pxContexts[ i ], 0x00, sizeof( pxContexts[ i ] ) );
+        memset( ( void * ) pxContexts[ i ], 0x00, sizeof( CommandContext_t ) );
         pxContexts[ i ]->xTaskToNotify = xTaskGetCurrentTaskHandle();
 
         /* Set the notification bit to be the publish number. This prevents this demo

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Multitask/DemoTasks/MultitaskMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Multitask/DemoTasks/MultitaskMQTTExample.c
@@ -112,11 +112,11 @@
 /* If no username is defined, then a client certificate/key is required. */
     #ifndef democonfigCLIENT_USERNAME
 
-        /*
-         *!!! Please note democonfigCLIENT_PRIVATE_KEY_PEM in used for
-         *!!! convenience of demonstration only.  Production devices should
-         *!!! store keys securely, such as within a secure element.
-         */
+/*
+ *!!! Please note democonfigCLIENT_PRIVATE_KEY_PEM in used for
+ *!!! convenience of demonstration only.  Production devices should
+ *!!! store keys securely, such as within a secure element.
+ */
 
         #ifndef democonfigCLIENT_CERTIFICATE_PEM
             #error "Please define client certificate(democonfigCLIENT_CERTIFICATE_PEM) in demo_config.h."
@@ -859,7 +859,7 @@ void vStartSimpleMQTTDemo( void )
      * MQTT operations, and creates additional tasks to add operations to that
      * queue. */
     xTaskCreate( prvMQTTDemoTask,          /* Function that implements the task. */
-                 "MQTTDemo",               /* Text name for the task - only used for debugging. */
+                 "DemoTask",               /* Text name for the task - only used for debugging. */
                  democonfigDEMO_STACKSIZE, /* Size of stack (in words, not bytes) to allocate for the task. */
                  NULL,                     /* Task parameter - not used in this case. */
                  tskIDLE_PRIORITY + 1,     /* Task priority, must be between 0 and configMAX_PRIORITIES - 1. */

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Multitask/DemoTasks/MultitaskMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Multitask/DemoTasks/MultitaskMQTTExample.c
@@ -24,26 +24,44 @@
  */
 
 /*
- * Demo for showing use of the managed MQTT API shared between multiple tasks.
- * This demo uses a thread safe queue to hold commands for interacting with the
- * MQTT API. There are four tasks to note in this demo:
- *  - A command (main) task for processing commands from the command queue while
- *    other tasks enqueue them. This task enters a loop, during which it processes
- *    commands from the command queue. If a termination command is received, it
- *    will break from the loop.
- *  - A publisher task for synchronous publishes. This task creates a series of
- *    publish operations to push to the command queue, which are then executed
- *    by the command task. This task uses synchronous publishes, meaning it will
- *    wait for each publish to complete before scheduling the next one.
- *  - A publisher task for asynchronous publishes. The difference between this
- *    task and the previous is that it will not wait for completion before
- *    scheduling the next publish, and checks them after all publishes have been
- *    enqueued. Note that the distinction between synchronous and asynchronous
- *    publishes is only in the behavior of the task, not in the actual publish
- *    command.
- *  - A subscriber task that creates an MQTT subscription to a topic filter
- *    matching the topics published on by the publishers. It loops while waiting
- *    for publish messages to be received.
+ * This demo shows how to use coreMQTT in a multithreaded environment - it does not
+ * yet go as far as encapsulating the MQTT library within its own agent (or daemon)
+ * task - although the prvCommandLoop() function demonstrates how that might be done.
+ * In this task prvCommandLoop() is only executed from a single thread and is the
+ * only function that is allowed to use the coreMQTT API directly.  Anything else
+ * needing to interact with the coreMQTT API does so by posting commands to
+ * prvCommandLoop() via a queue.  Future coreMQTT releases will build an agent into
+ * the library itself, and then encapsulate the queues into the implementation of a
+ * thread safe coreMQTT API.
+ *
+ * To use this demo with TLS set democonfigUSE_TLS to 1.  To use this demo without
+ * TLS (so plain text) set democonfigUSE_TLS to 0.  democonfigUSE_TLS is defined
+ * in demo_config.h.
+ *
+ *!!! Plain text connections are only used for ease of demonstration.  Do not send
+ *!!! sensitive data on unencrypted connections.  Production devices should used
+ *!!! mutually authenticated and encrypted connections.
+ *
+ * There are four tasks to note in this demo:
+ *  - prvMQTTDemoTask() manages multiple iterations of the demo.  Each iteration
+ *    creates the other tasks, calls prvCommandLoop() to handle the MQTT traffic,
+ *    then cleans up ready for the next iteration.
+ *  - prvSyncPublishTask() which demonstrates synchronous publishes. The task creates
+ *    a series of publish operations that are sent over the command queue to be
+ *    processed by prvCommandLoop(), waiting for each publish to complete before
+ *    sending the next.
+ *  - prvAsyncPublishTask() which demonstrates asynchronous publishes. Like
+ *    prvSyncPublishTask(), the task creates a series of publish operations that are
+ *    sent over the command queue to be processed by prvCommandLoop(), but unlike
+ *    prvSyncPublishTask() this task does not wait for each publish to be complete
+ *    until after all the publish commands are sent.  Note that the distinction
+ *    between synchronous and asynchronous publishes is only in the behavior of the
+ *    task, not in the actual publish command.
+ *  - prvSubscribeTask() which creates an MQTT subscription to a topic filter
+ *    matching the topics published on by the two publishing tasks, and in doing so,
+ *    ensures the demo received a publish command back for each publish command it
+ *    sends. It loops while waiting for publish messages to be received.
+ *
  * Tasks can have queues to hold received publish messages, and the command task
  * will push incoming publishes to the queue of each task that is subscribed to
  * the incoming topic.
@@ -83,70 +101,6 @@
 /**
  * These configuration settings are required to run the demo.
  */
-#ifndef democonfigCLIENT_IDENTIFIER
-
-/**
- * @brief The MQTT client identifier used in this example.  Each client identifier
- * must be unique so edit as required to ensure no two clients connecting to the
- * same broker use the same client identifier.
- *
- * @note Appending __TIME__ to the client id string will reduce the possibility of a
- * client id collision in the broker. Note that the appended time is the compilation
- * time. This client id can cause collision, if more than one instance of the same
- * binary is used at the same time to connect to the broker.
- */
-    #define democonfigCLIENT_IDENTIFIER    "testClient"__TIME__
-#endif
-
-/* Compile time error for some undefined configs, and provide default values
- * for others. */
-#ifndef democonfigMQTT_BROKER_ENDPOINT
-    #error "Please define democonfigMQTT_BROKER_ENDPOINT in demo_config.h."
-#endif
-
-#if defined( democonfigUSE_TLS ) && ( democonfigUSE_TLS == 1 )
-    #ifndef democonfigROOT_CA_PEM
-        #error "Please define Root CA certificate of the MQTT broker(democonfigROOT_CA_PEM) in demo_config.h."
-    #endif
-
-/* If no username is defined, then a client certificate/key is required. */
-    #ifndef democonfigCLIENT_USERNAME
-
-/*
- *!!! Please note democonfigCLIENT_PRIVATE_KEY_PEM in used for
- *!!! convenience of demonstration only.  Production devices should
- *!!! store keys securely, such as within a secure element.
- */
-
-        #ifndef democonfigCLIENT_CERTIFICATE_PEM
-            #error "Please define client certificate(democonfigCLIENT_CERTIFICATE_PEM) in demo_config.h."
-        #endif
-        #ifndef democonfigCLIENT_PRIVATE_KEY_PEM
-            #error "Please define client private key(democonfigCLIENT_PRIVATE_KEY_PEM) in demo_config.h."
-        #endif
-    #else
-
-/* If a username is defined, a client password also would need to be defined for
- * client authentication. */
-        #ifndef democonfigCLIENT_PASSWORD
-            #error "Please define client password(democonfigCLIENT_PASSWORD) in demo_config.h for client authentication based on username/password."
-        #endif
-
-/* AWS IoT MQTT broker port needs to be 443 for client authentication based on
- * username/password. */
-        #if defined( democonfigUSE_AWS_IOT_CORE_BROKER ) && democonfigMQTT_BROKER_PORT != 443
-            #error "Broker port(democonfigMQTT_BROKER_PORT) should be defined as 443 in demo_config.h for client authentication based on username/password in AWS IoT Core."
-        #endif
-    #endif /* ifndef democonfigCLIENT_USERNAME */
-
-    #ifndef democonfigMQTT_BROKER_PORT
-        #define democonfigMQTT_BROKER_PORT    ( 8883 )
-    #endif
-#else /* if defined( democonfigUSE_TLS ) && ( democonfigUSE_TLS == 1 ) */
-    #ifndef democonfigMQTT_BROKER_PORT
-        #define democonfigMQTT_BROKER_PORT    ( 1883 )
-    #endif
-#endif /* if defined( democonfigUSE_TLS ) && ( democonfigUSE_TLS == 1 ) */
 
 /**
  * @brief The size to use for the network buffer.
@@ -155,73 +109,6 @@
     #define mqttexampleNETWORK_BUFFER_SIZE    ( 1024U )
 #endif
 
-/**
- * @brief ALPN (Application-Layer Protocol Negotiation) protocol name for AWS IoT MQTT.
- *
- * This will be used if democonfigMQTT_BROKER_PORT is configured as 443 for the AWS IoT MQTT broker.
- * Please see more details about the ALPN protocol for AWS IoT MQTT endpoint
- * in the link below.
- * https://aws.amazon.com/blogs/iot/mqtt-with-tls-client-authentication-on-port-443-why-it-is-useful-and-how-it-works/
- */
-#define AWS_IOT_MQTT_ALPN           "\x0ex-amzn-mqtt-ca"
-
-/**
- * @brief This is the ALPN (Application-Layer Protocol Negotiation) string
- * required by AWS IoT for password-based authentication using TCP port 443.
- */
-#define AWS_IOT_CUSTOM_AUTH_ALPN    "\x04mqtt"
-
-/**
- * Provide default values for undefined configuration settings.
- */
-#ifndef democonfigOS_NAME
-    #define democonfigOS_NAME    "FreeRTOS"
-#endif
-
-#ifndef democonfigOS_VERSION
-    #define democonfigOS_VERSION    tskKERNEL_VERSION_NUMBER
-#endif
-
-#ifndef democonfigHARDWARE_PLATFORM_NAME
-    #define democonfigHARDWARE_PLATFORM_NAME    "WinSim"
-#endif
-
-#ifndef democonfigMQTT_LIB
-    #define democonfigMQTT_LIB    "core-mqtt@1.0.0"
-#endif
-
-/**
- * @brief The MQTT metrics string expected by AWS IoT.
- */
-#define AWS_IOT_METRICS_STRING                                 \
-    "?SDK=" democonfigOS_NAME "&Version=" democonfigOS_VERSION \
-    "&Platform=" democonfigHARDWARE_PLATFORM_NAME "&MQTTLib=" democonfigMQTT_LIB
-
-/**
- * @brief The length of the MQTT metrics string expected by AWS IoT.
- */
-#define AWS_IOT_METRICS_STRING_LENGTH    ( ( uint16_t ) ( sizeof( AWS_IOT_METRICS_STRING ) - 1 ) )
-
-#ifdef democonfigCLIENT_USERNAME
-
-/**
- * @brief Append the username with the metrics string if #democonfigCLIENT_USERNAME is defined.
- *
- * This is to support both metrics reporting and username/password based client
- * authentication by AWS IoT.
- */
-    #define CLIENT_USERNAME_WITH_METRICS    democonfigCLIENT_USERNAME AWS_IOT_METRICS_STRING
-#endif
-
-/**
- * @brief Length of client identifier.
- */
-#define democonfigCLIENT_IDENTIFIER_LENGTH           ( ( uint16_t ) ( sizeof( democonfigCLIENT_IDENTIFIER ) - 1 ) )
-
-/**
- * @brief Length of MQTT server host name.
- */
-#define democonfigBROKER_ENDPOINT_LENGTH             ( ( uint16_t ) ( sizeof( democonfigMQTT_BROKER_ENDPOINT ) - 1 ) )
 
 /**
  * @brief Timeout for receiving CONNACK packet in milliseconds.
@@ -533,13 +420,6 @@ static BaseType_t prvSocketDisconnect( NetworkContext_t * pxNetworkContext );
 static void prvMQTTClientSocketWakeupCallback( Socket_t pxSocket );
 
 /**
- * @brief Initialize context for a command.
- *
- * @param[in] pxContext Context to initialize.
- */
-static void prvInitializeCommandContext( CommandContext_t * pxContext );
-
-/**
  * @brief Track an operation by adding it to a list, indicating it is anticipating
  * an acknowledgment.
  *
@@ -767,6 +647,14 @@ static void prvMQTTDemoTask( void * pvParameters );
  * @return Time in milliseconds.
  */
 static uint32_t prvGetTimeMs( void );
+
+/**
+ * @brief Cleans any persistent sessions that may already exist
+ * This demo uses a persistent session that can be re-connected if disconnected.
+ * Clean any lingering sessions that may exist from previous executions of the
+ * demo.
+ */
+static void prvCleanExistingPersistentSession( void );
 
 /*-----------------------------------------------------------*/
 
@@ -1049,7 +937,7 @@ static MQTTStatus_t prvResumeSession( bool xSessionPresent )
         /* Resubscribe if needed. */
         if( j > 0 )
         {
-            prvInitializeCommandContext( &xResubscribeContext );
+            memset( ( void * ) &xResubscribeContext, 0x00, sizeof( xResubscribeContext ) );
             xResubscribeContext.pxSubscribeInfo = pxResendSubscriptions;
             xResubscribeContext.ulSubscriptionCount = j;
             /* Set to NULL so existing queues will not be overwritten. */
@@ -1217,18 +1105,6 @@ static void prvMQTTClientSocketWakeupCallback( Socket_t pxSocket )
         xResult = prvAddCommandToQueue( &xCommand );
         configASSERT( xResult == pdTRUE );
     }
-}
-
-/*-----------------------------------------------------------*/
-
-static void prvInitializeCommandContext( CommandContext_t * pxContext )
-{
-    pxContext->xIsComplete = false;
-    pxContext->pxResponseQueue = NULL;
-    pxContext->xReturnStatus = MQTTSuccess;
-    pxContext->pxPublishInfo = NULL;
-    pxContext->pxSubscribeInfo = NULL;
-    pxContext->ulSubscriptionCount = 0;
 }
 
 /*-----------------------------------------------------------*/
@@ -1742,7 +1618,6 @@ static void prvCommandLoop( void )
 {
     Command_t xCommand;
     Command_t xNewCommand;
-    Command_t * pxCommand;
     MQTTStatus_t xStatus = MQTTSuccess;
     static int lNumProcessed = 0;
     bool xTerminateReceived = false;
@@ -1758,9 +1633,7 @@ static void prvCommandLoop( void )
             continue;
         }
 
-        pxCommand = &xCommand;
-
-        xStatus = prvProcessCommand( pxCommand );
+        xStatus = prvProcessCommand( &xCommand );
 
         /* Add connect operation to front of queue if status was not successful. */
         if( xStatus != MQTTSuccess )
@@ -1778,15 +1651,17 @@ static void prvCommandLoop( void )
 
         /* Delay after sending a subscribe. This is to so that the broker
          * creates a subscription for us before processing our next publish,
-         * which should be immediately after this. */
-        if( pxCommand->xCommandType == SUBSCRIBE )
+         * which should be immediately after this.  Only required because the
+         * subscribe and publish commands are coming from separate tasks, which
+         * would not normally be the case. */
+        if( xCommand.xCommandType == SUBSCRIBE )
         {
             LogDebug( ( "Sleeping for %d ms after sending SUBSCRIBE packet.", mqttexampleSUBSCRIBE_TASK_DELAY_MS ) );
             vTaskDelay( mqttexampleSUBSCRIBE_TASK_DELAY_MS );
         }
 
         /* Terminate the loop if we receive the termination command. */
-        if( pxCommand->xCommandType == TERMINATE )
+        if( xCommand.xCommandType == TERMINATE )
         {
             xTerminateReceived = true;
             break;
@@ -1800,8 +1675,7 @@ static void prvCommandLoop( void )
     configASSERT( xTerminateReceived == true );
 
     LogInfo( ( "Creating Disconnect operation." ) );
-    prvCreateCommand( DISCONNECT, NULL, NULL, &xNewCommand );
-    prvProcessCommand( &xNewCommand );
+    MQTT_Disconnect( &globalMqttContext );
     LogInfo( ( "Disconnected from broker." ) );
 }
 
@@ -1873,7 +1747,7 @@ void prvSyncPublishTask( void * pvParameters )
         snprintf( topicBuf, mqttexampleDEMO_BUFFER_SIZE, mqttexamplePUBLISH_TOPIC_FORMAT_STRING, "sync", i + 1 );
         xPublishInfo.topicNameLength = ( uint16_t ) strlen( topicBuf );
 
-        prvInitializeCommandContext( &xContext );
+        memset( ( void * ) &xContext, 0x00, sizeof( xContext ) );
         xContext.xTaskToNotify = xTaskGetCurrentTaskHandle();
         xContext.ulNotificationBit = 1 << i;
         xContext.pxPublishInfo = &xPublishInfo;
@@ -1935,7 +1809,7 @@ void prvAsyncPublishTask( void * pvParameters )
     for( int i = 0; i < mqttexamplePUBLISH_COUNT / 2; i++ )
     {
         pxContexts[ i ] = ( CommandContext_t * ) pvPortMalloc( sizeof( CommandContext_t ) );
-        prvInitializeCommandContext( pxContexts[ i ] );
+        memset( ( void * ) pxContexts[ i ], 0x00, sizeof( pxContexts[ i ] ) );
         pxContexts[ i ]->xTaskToNotify = xTaskGetCurrentTaskHandle();
 
         /* Set the notification bit to be the publish number. This prevents this demo
@@ -2023,7 +1897,7 @@ void prvSubscribeTask( void * pvParameters )
     LogInfo( ( "Topic filter: %.*s", xSubscribeInfo.topicFilterLength, xSubscribeInfo.pTopicFilter ) );
 
     /* Create the context and subscribe command. */
-    prvInitializeCommandContext( &xContext );
+    memset( &xContext, 0x00, sizeof( xContext ) );
     xContext.pxResponseQueue = xSubscriberResponseQueue;
     xContext.xTaskToNotify = xTaskGetCurrentTaskHandle();
     xContext.ulNotificationBit = mqttexampleSUBSCRIBE_COMPLETE_BIT;
@@ -2097,7 +1971,7 @@ void prvSubscribeTask( void * pvParameters )
 
     LogInfo( ( "Finished receiving\n" ) );
     prvCreateCommand( UNSUBSCRIBE, &xContext, prvCommandCallback, &xCommand );
-    prvInitializeCommandContext( &xContext );
+    memset( ( void * ) &xContext, 0x00, sizeof( xContext ) );
     xContext.pxResponseQueue = xSubscriberResponseQueue;
     xContext.xTaskToNotify = xTaskGetCurrentTaskHandle();
     xContext.ulNotificationBit = mqttexampleUNSUBSCRIBE_COMPLETE_BIT;
@@ -2131,12 +2005,38 @@ void prvSubscribeTask( void * pvParameters )
 
 /*-----------------------------------------------------------*/
 
+static void prvCleanExistingPersistentSession( void )
+{
+    BaseType_t xNetworkStatus = pdFAIL;
+    MQTTStatus_t xMQTTStatus;
+
+    /* Connect to the broker. We connect here with the "clean session" flag set
+     * to true in order to clear any prior state in the broker. We will disconnect
+     * and later form a persistent session, so that it may be resumed if the
+     * network suddenly disconnects. */
+    xNetworkStatus = prvSocketConnect( &xNetworkContext );
+    configASSERT( xNetworkStatus == pdPASS );
+    LogInfo( ( "Creating a clean session to clear any broker state information." ) );
+    xMQTTStatus = prvMQTTInit( &globalMqttContext, &xNetworkContext );
+    configASSERT( xMQTTStatus == MQTTSuccess );
+    xMQTTStatus = prvMQTTConnect( &globalMqttContext, true );
+    configASSERT( xMQTTStatus == MQTTSuccess );
+
+    /* Disconnect. */
+    xMQTTStatus = MQTT_Disconnect( &globalMqttContext );
+    configASSERT( xMQTTStatus == MQTTSuccess );
+    xNetworkStatus = prvSocketDisconnect( &xNetworkContext );
+    configASSERT( xNetworkStatus == pdPASS );
+}
+
+/*-----------------------------------------------------------*/
+
 static void prvMQTTDemoTask( void * pvParameters )
 {
     BaseType_t xNetworkStatus = pdFAIL;
+    MQTTStatus_t xMQTTStatus;
     BaseType_t xResult = pdFALSE;
     uint32_t ulNotification = 0;
-    MQTTStatus_t xMQTTStatus;
     uint32_t ulExpectedNotifications = mqttexamplePUBLISHER_SYNC_COMPLETE_BIT |
                                        mqttexampleSUBSCRIBE_TASK_COMPLETE_BIT |
                                        mqttexamplePUBLISHER_ASYNC_COMPLETE_BIT;
@@ -2156,23 +2056,10 @@ static void prvMQTTDemoTask( void * pvParameters )
      * synchronization primitives. */
     xDefaultResponseQueue = xQueueCreate( 1, sizeof( PublishElement_t ) );
 
-    /* Connect to the broker. We connect here with the "clean session" flag set
-     * to true in order to clear any prior state in the broker. We will disconnect
-     * and later form a persistent session, so that it may be resumed if the
-     * network suddenly disconnects. */
-    xNetworkStatus = prvSocketConnect( &xNetworkContext );
-    configASSERT( xNetworkStatus == pdPASS );
-    LogInfo( ( "Creating a clean session to clear any broker state information." ) );
-    xMQTTStatus = prvMQTTInit( &globalMqttContext, &xNetworkContext );
-    configASSERT( xMQTTStatus == MQTTSuccess );
-    xMQTTStatus = prvMQTTConnect( &globalMqttContext, true );
-    configASSERT( xMQTTStatus == MQTTSuccess );
-
-    /* Disconnect. */
-    xMQTTStatus = MQTT_Disconnect( &globalMqttContext );
-    configASSERT( xMQTTStatus == MQTTSuccess );
-    xNetworkStatus = prvSocketDisconnect( &xNetworkContext );
-    configASSERT( xNetworkStatus == pdPASS );
+    /* This demo uses a persistent session that can be re-connected if disconnected.
+     * Clean any lingering sessions that may exist from previous executions of the
+     * demo. */
+    prvCleanExistingPersistentSession();
 
     for( ; ; )
     {
@@ -2188,8 +2075,9 @@ static void prvMQTTDemoTask( void * pvParameters )
         configASSERT( xMQTTStatus == MQTTSuccess );
         configASSERT( globalMqttContext.connectStatus == MQTTConnected );
 
-        /* Give subscriber task higher priority so the subscribe will be processed before the first publish.
-         * This must be less than or equal to the priority of the main task. */
+        /* Give subscriber task higher priority so the subscribe will be processed
+         * before the first publish.  This must be less than or equal to the priority of
+         * the main task. */
         xResult = xTaskCreate( prvSubscribeTask, "Subscriber", democonfigDEMO_STACKSIZE, NULL, tskIDLE_PRIORITY + 1, &xSubscribeTask );
         configASSERT( xResult == pdPASS );
         xResult = xTaskCreate( prvSyncPublishTask, "SyncPublisher", democonfigDEMO_STACKSIZE, NULL, tskIDLE_PRIORITY, &xSyncPublisherTask );
@@ -2218,7 +2106,7 @@ static void prvMQTTDemoTask( void * pvParameters )
         xNetworkStatus = prvSocketDisconnect( &xNetworkContext );
         configASSERT( xNetworkStatus == pdPASS );
 
-        LogInfo( ( "prvMQTTDemoTask() completed an iteration successfully. Total free heap is %u.\r\n", xPortGetFreeHeapSize() ) );
+        LogInfo( ( "\r\n\r\nprvMQTTDemoTask() completed an iteration successfully. Total free heap is %u.\r\n", xPortGetFreeHeapSize() ) );
         LogInfo( ( "Demo completed successfully.\r\n" ) );
         LogInfo( ( "Short delay before starting the next iteration.... \r\n\r\n" ) );
         vTaskDelay( mqttexampleDELAY_BETWEEN_DEMO_ITERATIONS );

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Multitask/core_mqtt_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Multitask/core_mqtt_config.h
@@ -58,7 +58,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Map the SdkLog macro to the logging function to enable logging
  * on Windows simulator. */
-#define SdkLog( message )    vLoggingPrintf message
+#ifndef SdkLog
+    #define SdkLog( message )    vLoggingPrintf message
+#endif
 
 #include "logging_stack.h"
 /************ End of logging configuration ****************/

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Multitask/core_mqtt_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Multitask/core_mqtt_config.h
@@ -49,6 +49,17 @@
     #define LIBRARY_LOG_LEVEL    LOG_ERROR
 #endif
 
+/* Prototype for the function used to print to console on Windows simulator
+ * of FreeRTOS.
+ * The function prints to the console before the network is connected;
+ * then a UDP port after the network has connected. */
+extern void vLoggingPrintf( const char * pcFormatString,
+                            ... );
+
+/* Map the SdkLog macro to the logging function to enable logging
+ * on Windows simulator. */
+#define SdkLog( message )    vLoggingPrintf message
+
 #include "logging_stack.h"
 /************ End of logging configuration ****************/
 

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Multitask/demo_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Multitask/demo_config.h
@@ -259,4 +259,146 @@ extern void vLoggingPrintf( const char * pcFormatString,
  */
 #define democonfigDEMO_STACKSIZE            configMINIMAL_STACK_SIZE
 
+
+
+
+
+
+
+/**********************************************************************************
+ * Error checks and derived values only below here - do not edit below here. -----*
+ **********************************************************************************/
+
+
+/* Compile time error for some undefined configs, and provide default values
+ * for others. */
+#ifndef democonfigMQTT_BROKER_ENDPOINT
+    #error "Please define democonfigMQTT_BROKER_ENDPOINT in demo_config.h."
+#endif
+
+#ifndef democonfigCLIENT_IDENTIFIER
+    /**
+     * @brief The MQTT client identifier used in this example.  Each client identifier
+     * must be unique so edit as required to ensure no two clients connecting to the
+     * same broker use the same client identifier.  Using a #define is for convenience
+     * of demonstration only - production devices should use something unique to the
+     * device that can be read from software - such as a production serial number.
+     */
+     #error  "Please define democonfigCLIENT_IDENTIFIER in demo_config.h to something unique for this device."
+#endif
+
+
+#if defined( democonfigUSE_TLS ) && ( democonfigUSE_TLS == 1 )
+    #ifndef democonfigROOT_CA_PEM
+        #error "Please define Root CA certificate of the MQTT broker(democonfigROOT_CA_PEM) in demo_config.h."
+    #endif
+
+/* If no username is defined, then a client certificate/key is required. */
+    #ifndef democonfigCLIENT_USERNAME
+
+        /*
+         *!!! Please note democonfigCLIENT_PRIVATE_KEY_PEM in used for
+         *!!! convenience of demonstration only.  Production devices should
+         *!!! store keys securely, such as within a secure element.
+         */
+
+        #ifndef democonfigCLIENT_CERTIFICATE_PEM
+            #error "Please define client certificate(democonfigCLIENT_CERTIFICATE_PEM) in demo_config.h."
+        #endif
+        #ifndef democonfigCLIENT_PRIVATE_KEY_PEM
+            #error "Please define client private key(democonfigCLIENT_PRIVATE_KEY_PEM) in demo_config.h."
+        #endif
+    #else
+
+/* If a username is defined, a client password also would need to be defined for
+ * client authentication. */
+        #ifndef democonfigCLIENT_PASSWORD
+            #error "Please define client password(democonfigCLIENT_PASSWORD) in demo_config.h for client authentication based on username/password."
+        #endif
+
+/* AWS IoT MQTT broker port needs to be 443 for client authentication based on
+ * username/password. */
+        #if defined( democonfigUSE_AWS_IOT_CORE_BROKER ) && democonfigMQTT_BROKER_PORT != 443
+            #error "Broker port(democonfigMQTT_BROKER_PORT) should be defined as 443 in demo_config.h for client authentication based on username/password in AWS IoT Core."
+        #endif
+    #endif /* ifndef democonfigCLIENT_USERNAME */
+
+    #ifndef democonfigMQTT_BROKER_PORT
+        #define democonfigMQTT_BROKER_PORT    ( 8883 )
+    #endif
+#else /* if defined( democonfigUSE_TLS ) && ( democonfigUSE_TLS == 1 ) */
+    #ifndef democonfigMQTT_BROKER_PORT
+        #define democonfigMQTT_BROKER_PORT    ( 1883 )
+    #endif
+#endif /* if defined( democonfigUSE_TLS ) && ( democonfigUSE_TLS == 1 ) */
+
+/**
+ * @brief ALPN (Application-Layer Protocol Negotiation) protocol name for AWS IoT MQTT.
+ *
+ * This will be used if democonfigMQTT_BROKER_PORT is configured as 443 for the AWS IoT MQTT broker.
+ * Please see more details about the ALPN protocol for AWS IoT MQTT endpoint
+ * in the link below.
+ * https://aws.amazon.com/blogs/iot/mqtt-with-tls-client-authentication-on-port-443-why-it-is-useful-and-how-it-works/
+ */
+#define AWS_IOT_MQTT_ALPN           "\x0ex-amzn-mqtt-ca"
+
+/**
+ * @brief This is the ALPN (Application-Layer Protocol Negotiation) string
+ * required by AWS IoT for password-based authentication using TCP port 443.
+ */
+#define AWS_IOT_CUSTOM_AUTH_ALPN    "\x04mqtt"
+
+/**
+ * Provide default values for undefined configuration settings.
+ */
+#ifndef democonfigOS_NAME
+    #define democonfigOS_NAME    "FreeRTOS"
+#endif
+
+#ifndef democonfigOS_VERSION
+    #define democonfigOS_VERSION    tskKERNEL_VERSION_NUMBER
+#endif
+
+#ifndef democonfigHARDWARE_PLATFORM_NAME
+    #define democonfigHARDWARE_PLATFORM_NAME    "WinSim"
+#endif
+
+#ifndef democonfigMQTT_LIB
+    #define democonfigMQTT_LIB    "core-mqtt@1.0.0"
+#endif
+
+/**
+ * @brief The MQTT metrics string expected by AWS IoT.
+ */
+#define AWS_IOT_METRICS_STRING                                 \
+    "?SDK=" democonfigOS_NAME "&Version=" democonfigOS_VERSION \
+    "&Platform=" democonfigHARDWARE_PLATFORM_NAME "&MQTTLib=" democonfigMQTT_LIB
+
+/**
+ * @brief The length of the MQTT metrics string expected by AWS IoT.
+ */
+#define AWS_IOT_METRICS_STRING_LENGTH    ( ( uint16_t ) ( sizeof( AWS_IOT_METRICS_STRING ) - 1 ) )
+
+#ifdef democonfigCLIENT_USERNAME
+
+/**
+ * @brief Append the username with the metrics string if #democonfigCLIENT_USERNAME is defined.
+ *
+ * This is to support both metrics reporting and username/password based client
+ * authentication by AWS IoT.
+ */
+    #define CLIENT_USERNAME_WITH_METRICS    democonfigCLIENT_USERNAME AWS_IOT_METRICS_STRING
+#endif
+
+/**
+ * @brief Length of client identifier.
+ */
+#define democonfigCLIENT_IDENTIFIER_LENGTH           ( ( uint16_t ) ( sizeof( democonfigCLIENT_IDENTIFIER ) - 1 ) )
+
+/**
+ * @brief Length of MQTT server host name.
+ */
+#define democonfigBROKER_ENDPOINT_LENGTH             ( ( uint16_t ) ( sizeof( democonfigMQTT_BROKER_ENDPOINT ) - 1 ) )
+
+
 #endif /* DEMO_CONFIG_H */

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Multitask/demo_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Multitask/demo_config.h
@@ -48,6 +48,18 @@
 #ifndef LIBRARY_LOG_LEVEL
     #define LIBRARY_LOG_LEVEL    LOG_INFO
 #endif
+
+/* Prototype for the function used to print to console on Windows simulator
+ * of FreeRTOS.
+ * The function prints to the console before the network is connected;
+ * then a UDP port after the network has connected. */
+extern void vLoggingPrintf( const char * pcFormatString,
+                            ... );
+
+/* Map the SdkLog macro to the logging function to enable logging
+ * on Windows simulator. */
+#define SdkLog( message )    vLoggingPrintf message
+
 #include "logging_stack.h"
 
 /************ End of logging configuration ****************/

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Multitask/demo_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Multitask/demo_config.h
@@ -58,7 +58,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Map the SdkLog macro to the logging function to enable logging
  * on Windows simulator. */
-#define SdkLog( message )    vLoggingPrintf message
+#ifndef SdkLog
+    #define SdkLog( message )    vLoggingPrintf message
+#endif
 
 #include "logging_stack.h"
 
@@ -261,13 +263,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 
 
-
-
-
-
 /**********************************************************************************
- * Error checks and derived values only below here - do not edit below here. -----*
- **********************************************************************************/
+* Error checks and derived values only below here - do not edit below here. -----*
+**********************************************************************************/
 
 
 /* Compile time error for some undefined configs, and provide default values
@@ -277,14 +275,15 @@ extern void vLoggingPrintf( const char * pcFormatString,
 #endif
 
 #ifndef democonfigCLIENT_IDENTIFIER
-    /**
-     * @brief The MQTT client identifier used in this example.  Each client identifier
-     * must be unique so edit as required to ensure no two clients connecting to the
-     * same broker use the same client identifier.  Using a #define is for convenience
-     * of demonstration only - production devices should use something unique to the
-     * device that can be read from software - such as a production serial number.
-     */
-     #error  "Please define democonfigCLIENT_IDENTIFIER in demo_config.h to something unique for this device."
+
+/**
+ * @brief The MQTT client identifier used in this example.  Each client identifier
+ * must be unique so edit as required to ensure no two clients connecting to the
+ * same broker use the same client identifier.  Using a #define is for convenience
+ * of demonstration only - production devices should use something unique to the
+ * device that can be read from software - such as a production serial number.
+ */
+    #error  "Please define democonfigCLIENT_IDENTIFIER in demo_config.h to something unique for this device."
 #endif
 
 
@@ -296,11 +295,11 @@ extern void vLoggingPrintf( const char * pcFormatString,
 /* If no username is defined, then a client certificate/key is required. */
     #ifndef democonfigCLIENT_USERNAME
 
-        /*
-         *!!! Please note democonfigCLIENT_PRIVATE_KEY_PEM in used for
-         *!!! convenience of demonstration only.  Production devices should
-         *!!! store keys securely, such as within a secure element.
-         */
+/*
+ *!!! Please note democonfigCLIENT_PRIVATE_KEY_PEM in used for
+ *!!! convenience of demonstration only.  Production devices should
+ *!!! store keys securely, such as within a secure element.
+ */
 
         #ifndef democonfigCLIENT_CERTIFICATE_PEM
             #error "Please define client certificate(democonfigCLIENT_CERTIFICATE_PEM) in demo_config.h."
@@ -393,12 +392,12 @@ extern void vLoggingPrintf( const char * pcFormatString,
 /**
  * @brief Length of client identifier.
  */
-#define democonfigCLIENT_IDENTIFIER_LENGTH           ( ( uint16_t ) ( sizeof( democonfigCLIENT_IDENTIFIER ) - 1 ) )
+#define democonfigCLIENT_IDENTIFIER_LENGTH    ( ( uint16_t ) ( sizeof( democonfigCLIENT_IDENTIFIER ) - 1 ) )
 
 /**
  * @brief Length of MQTT server host name.
  */
-#define democonfigBROKER_ENDPOINT_LENGTH             ( ( uint16_t ) ( sizeof( democonfigMQTT_BROKER_ENDPOINT ) - 1 ) )
+#define democonfigBROKER_ENDPOINT_LENGTH      ( ( uint16_t ) ( sizeof( democonfigMQTT_BROKER_ENDPOINT ) - 1 ) )
 
 
 #endif /* DEMO_CONFIG_H */

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Multitask/readme.url
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Multitask/readme.url
@@ -2,4 +2,4 @@
 Prop3=19,11
 [InternetShortcut]
 IDList=
-URL=https://www.freertos.org/mqtt/index.html
+URL=https://www.freertos.org/mqtt/rtos_mqtt_example.html

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/DemoTasks/MutualAuthMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/DemoTasks/MutualAuthMQTTExample.c
@@ -73,11 +73,11 @@
 /* If no username is defined, then a client certificate/key is required. */
 #ifndef democonfigCLIENT_USERNAME
 
-    /*
-     *!!! Please note democonfigCLIENT_PRIVATE_KEY_PEM in used for
-     *!!! convenience of demonstration only.  Production devices should
-     *!!! store keys securely, such as within a secure element.
-     */
+/*
+ *!!! Please note democonfigCLIENT_PRIVATE_KEY_PEM in used for
+ *!!! convenience of demonstration only.  Production devices should
+ *!!! store keys securely, such as within a secure element.
+ */
 
     #ifndef democonfigCLIENT_CERTIFICATE_PEM
         #error "Please define client certificate(democonfigCLIENT_CERTIFICATE_PEM) in demo_config.h."
@@ -432,7 +432,7 @@ void vStartSimpleMQTTDemo( void )
      * connect, subscribe, publish, unsubscribe and disconnect from the MQTT
      * broker. */
     xTaskCreate( prvMQTTDemoTask,          /* Function that implements the task. */
-                 "MQTTDemo",               /* Text name for the task - only used for debugging. */
+                 "DemoTask",               /* Text name for the task - only used for debugging. */
                  democonfigDEMO_STACKSIZE, /* Size of stack (in words, not bytes) to allocate for the task. */
                  NULL,                     /* Task parameter - not used in this case. */
                  tskIDLE_PRIORITY,         /* Task priority, must be between 0 and configMAX_PRIORITIES - 1. */

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/core_mqtt_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/core_mqtt_config.h
@@ -56,7 +56,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Map the SdkLog macro to the logging function to enable logging
  * on Windows simulator. */
-#define SdkLog( message )    vLoggingPrintf message
+#ifndef SdkLog
+    #define SdkLog( message )    vLoggingPrintf message
+#endif
 
 #include "logging_stack.h"
 /************ End of logging configuration ****************/

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/core_mqtt_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/core_mqtt_config.h
@@ -47,6 +47,17 @@
     #define LIBRARY_LOG_LEVEL    LOG_ERROR
 #endif
 
+/* Prototype for the function used to print to console on Windows simulator
+ * of FreeRTOS.
+ * The function prints to the console before the network is connected;
+ * then a UDP port after the network has connected. */
+extern void vLoggingPrintf( const char * pcFormatString,
+                            ... );
+
+/* Map the SdkLog macro to the logging function to enable logging
+ * on Windows simulator. */
+#define SdkLog( message )    vLoggingPrintf message
+
 #include "logging_stack.h"
 /************ End of logging configuration ****************/
 

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/demo_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/demo_config.h
@@ -61,7 +61,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Map the SdkLog macro to the logging function to enable logging
  * on Windows simulator. */
-#define SdkLog( message )    vLoggingPrintf message
+#ifndef SdkLog
+    #define SdkLog( message )    vLoggingPrintf message
+#endif
 
 #include "logging_stack.h"
 

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/demo_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/demo_config.h
@@ -51,6 +51,18 @@
 #ifndef LIBRARY_LOG_LEVEL
     #define LIBRARY_LOG_LEVEL    LOG_INFO
 #endif
+
+/* Prototype for the function used to print to console on Windows simulator
+ * of FreeRTOS.
+ * The function prints to the console before the network is connected;
+ * then a UDP port after the network has connected. */
+extern void vLoggingPrintf( const char * pcFormatString,
+                            ... );
+
+/* Map the SdkLog macro to the logging function to enable logging
+ * on Windows simulator. */
+#define SdkLog( message )    vLoggingPrintf message
+
 #include "logging_stack.h"
 
 /************ End of logging configuration ****************/

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/readme.url
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/readme.url
@@ -2,4 +2,4 @@
 Prop3=19,11
 [InternetShortcut]
 IDList=
-URL=https://www.freertos.org/mqtt/index.html
+URL=https://www.freertos.org/mqtt/mutual-authentication-mqtt-example.html

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Plain_Text/DemoTasks/PlaintextMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Plain_Text/DemoTasks/PlaintextMQTTExample.c
@@ -327,7 +327,7 @@ void vStartSimpleMQTTDemo( void )
      * connect, subscribe, publish, unsubscribe and disconnect from the MQTT
      * broker. */
     xTaskCreate( prvMQTTDemoTask,          /* Function that implements the task. */
-                 "MQTTDemo",               /* Text name for the task - only used for debugging. */
+                 "DemoTask",               /* Text name for the task - only used for debugging. */
                  democonfigDEMO_STACKSIZE, /* Size of stack (in words, not bytes) to allocate for the task. */
                  NULL,                     /* Task parameter - not used in this case. */
                  tskIDLE_PRIORITY,         /* Task priority, must be between 0 and configMAX_PRIORITIES - 1. */

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Plain_Text/core_mqtt_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Plain_Text/core_mqtt_config.h
@@ -58,7 +58,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Map the SdkLog macro to the logging function to enable logging
  * on Windows simulator. */
-#define SdkLog( message )    vLoggingPrintf message
+#ifndef SdkLog
+    #define SdkLog( message )    vLoggingPrintf message
+#endif
 
 #include "logging_stack.h"
 /************ End of logging configuration ****************/

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Plain_Text/core_mqtt_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Plain_Text/core_mqtt_config.h
@@ -49,6 +49,17 @@
     #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
+/* Prototype for the function used to print to console on Windows simulator
+ * of FreeRTOS.
+ * The function prints to the console before the network is connected;
+ * then a UDP port after the network has connected. */
+extern void vLoggingPrintf( const char * pcFormatString,
+                            ... );
+
+/* Map the SdkLog macro to the logging function to enable logging
+ * on Windows simulator. */
+#define SdkLog( message )    vLoggingPrintf message
+
 #include "logging_stack.h"
 /************ End of logging configuration ****************/
 

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Plain_Text/demo_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Plain_Text/demo_config.h
@@ -59,7 +59,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Map the SdkLog macro to the logging function to enable logging
  * on Windows simulator. */
-#define SdkLog( message )    vLoggingPrintf message
+#ifndef SdkLog
+    #define SdkLog( message )    vLoggingPrintf message
+#endif
 
 #include "logging_stack.h"
 

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Plain_Text/demo_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Plain_Text/demo_config.h
@@ -49,6 +49,18 @@
 #ifndef LIBRARY_LOG_LEVEL
     #define LIBRARY_LOG_LEVEL    LOG_INFO
 #endif
+
+/* Prototype for the function used to print to console on Windows simulator
+ * of FreeRTOS.
+ * The function prints to the console before the network is connected;
+ * then a UDP port after the network has connected. */
+extern void vLoggingPrintf( const char * pcFormatString,
+                            ... );
+
+/* Map the SdkLog macro to the logging function to enable logging
+ * on Windows simulator. */
+#define SdkLog( message )    vLoggingPrintf message
+
 #include "logging_stack.h"
 
 /************ End of logging configuration ****************/

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Plain_Text/readme.url
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Plain_Text/readme.url
@@ -2,4 +2,4 @@
 Prop3=19,11
 [InternetShortcut]
 IDList=
-URL=https://www.freertos.org/mqtt/index.html
+URL=https://www.freertos.org/mqtt/basic-mqtt-example.html

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Serializer/DemoTasks/SerializerMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Serializer/DemoTasks/SerializerMQTTExample.c
@@ -383,7 +383,7 @@ void vStartSimpleMQTTDemo( void )
      * connect, subscribe, publish, unsubscribe and disconnect from the MQTT
      * broker. */
     xTaskCreate( prvMQTTDemoTask,          /* Function that implements the task. */
-                 "MQTTSerializerDemo",     /* Text name for the task - only used for debugging. */
+                 "DemoTask",               /* Text name for the task - only used for debugging. */
                  democonfigDEMO_STACKSIZE, /* Size of stack (in words, not bytes) to allocate for the task. */
                  NULL,                     /* Task parameter - not used in this case. */
                  tskIDLE_PRIORITY,         /* Task priority, must be between 0 and configMAX_PRIORITIES - 1. */

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Serializer/core_mqtt_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Serializer/core_mqtt_config.h
@@ -58,7 +58,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Map the SdkLog macro to the logging function to enable logging
  * on Windows simulator. */
-#define SdkLog( message )    vLoggingPrintf message
+#ifndef SdkLog
+    #define SdkLog( message )    vLoggingPrintf message
+#endif
 
 #include "logging_stack.h"
 /************ End of logging configuration ****************/

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Serializer/core_mqtt_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Serializer/core_mqtt_config.h
@@ -49,6 +49,17 @@
     #define LIBRARY_LOG_LEVEL    LOG_INFO
 #endif
 
+/* Prototype for the function used to print to console on Windows simulator
+ * of FreeRTOS.
+ * The function prints to the console before the network is connected;
+ * then a UDP port after the network has connected. */
+extern void vLoggingPrintf( const char * pcFormatString,
+                            ... );
+
+/* Map the SdkLog macro to the logging function to enable logging
+ * on Windows simulator. */
+#define SdkLog( message )    vLoggingPrintf message
+
 #include "logging_stack.h"
 /************ End of logging configuration ****************/
 

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Serializer/demo_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Serializer/demo_config.h
@@ -59,7 +59,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Map the SdkLog macro to the logging function to enable logging
  * on Windows simulator. */
-#define SdkLog( message )    vLoggingPrintf message
+#ifndef SdkLog
+    #define SdkLog( message )    vLoggingPrintf message
+#endif
 
 #include "logging_stack.h"
 

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Serializer/demo_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Serializer/demo_config.h
@@ -49,6 +49,18 @@
 #ifndef LIBRARY_LOG_LEVEL
     #define LIBRARY_LOG_LEVEL    LOG_INFO
 #endif
+
+/* Prototype for the function used to print to console on Windows simulator
+ * of FreeRTOS.
+ * The function prints to the console before the network is connected;
+ * then a UDP port after the network has connected. */
+extern void vLoggingPrintf( const char * pcFormatString,
+                            ... );
+
+/* Map the SdkLog macro to the logging function to enable logging
+ * on Windows simulator. */
+#define SdkLog( message )    vLoggingPrintf message
+
 #include "logging_stack.h"
 
 /************ End of logging configuration ****************/

--- a/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/DemoTasks/MutualAuthMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/DemoTasks/MutualAuthMQTTExample.c
@@ -299,7 +299,7 @@ void vStartPKCSMutualAuthDemo( void )
      * connect, subscribe, publish, unsubscribe and disconnect from the MQTT
      * broker. */
     xTaskCreate( prvMQTTDemoTask,          /* Function that implements the task. */
-                 "MQTTDemo",               /* Text name for the task - only used for debugging. */
+                 "DemoTask",               /* Text name for the task - only used for debugging. */
                  democonfigDEMO_STACKSIZE, /* Size of stack (in words, not bytes) to allocate for the task. */
                  NULL,                     /* Task parameter - not used in this case. */
                  tskIDLE_PRIORITY,         /* Task priority, must be between 0 and configMAX_PRIORITIES - 1. */

--- a/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/core_mqtt_config.h
+++ b/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/core_mqtt_config.h
@@ -56,7 +56,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Map the SdkLog macro to the logging function to enable logging
  * on Windows simulator. */
-#define SdkLog( message )    vLoggingPrintf message
+#ifndef SdkLog
+    #define SdkLog( message )    vLoggingPrintf message
+#endif
 
 #include "logging_stack.h"
 /************ End of logging configuration ****************/

--- a/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/core_mqtt_config.h
+++ b/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/core_mqtt_config.h
@@ -47,6 +47,17 @@
     #define LIBRARY_LOG_LEVEL    LOG_ERROR
 #endif
 
+/* Prototype for the function used to print to console on Windows simulator
+ * of FreeRTOS.
+ * The function prints to the console before the network is connected;
+ * then a UDP port after the network has connected. */
+extern void vLoggingPrintf( const char * pcFormatString,
+                            ... );
+
+/* Map the SdkLog macro to the logging function to enable logging
+ * on Windows simulator. */
+#define SdkLog( message )    vLoggingPrintf message
+
 #include "logging_stack.h"
 /************ End of logging configuration ****************/
 

--- a/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/core_pkcs11_config.h
+++ b/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/core_pkcs11_config.h
@@ -65,7 +65,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Map the SdkLog macro to the logging function to enable logging
  * on Windows simulator. */
-#define SdkLog( message )    vLoggingPrintf message
+#ifndef SdkLog
+    #define SdkLog( message )    vLoggingPrintf message
+#endif
 
 #include "logging_stack.h"
 

--- a/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/core_pkcs11_config.h
+++ b/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/core_pkcs11_config.h
@@ -56,6 +56,17 @@
     #define LIBRARY_LOG_LEVEL    LOG_ERROR
 #endif
 
+/* Prototype for the function used to print to console on Windows simulator
+ * of FreeRTOS.
+ * The function prints to the console before the network is connected;
+ * then a UDP port after the network has connected. */
+extern void vLoggingPrintf( const char * pcFormatString,
+                            ... );
+
+/* Map the SdkLog macro to the logging function to enable logging
+ * on Windows simulator. */
+#define SdkLog( message )    vLoggingPrintf message
+
 #include "logging_stack.h"
 
 /**

--- a/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/demo_config.h
+++ b/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/demo_config.h
@@ -61,7 +61,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Map the SdkLog macro to the logging function to enable logging
  * on Windows simulator. */
-#define SdkLog( message )    vLoggingPrintf message
+#ifndef SdkLog
+    #define SdkLog( message )    vLoggingPrintf message
+#endif
 
 #include "logging_stack.h"
 

--- a/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/demo_config.h
+++ b/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/demo_config.h
@@ -51,6 +51,18 @@
 #ifndef LIBRARY_LOG_LEVEL
     #define LIBRARY_LOG_LEVEL    LOG_INFO
 #endif
+
+/* Prototype for the function used to print to console on Windows simulator
+ * of FreeRTOS.
+ * The function prints to the console before the network is connected;
+ * then a UDP port after the network has connected. */
+extern void vLoggingPrintf( const char * pcFormatString,
+                            ... );
+
+/* Map the SdkLog macro to the logging function to enable logging
+ * on Windows simulator. */
+#define SdkLog( message )    vLoggingPrintf message
+
 #include "logging_stack.h"
 
 /************ End of logging configuration ****************/

--- a/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/main.c
+++ b/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/main.c
@@ -26,7 +26,7 @@
  */
 
 /***
- * See https://www.FreeRTOS.org/pkcs11/index.html for configuration and usage instructions.
+ * See https://www.FreeRTOS.org/pkcs11/ for configuration and usage instructions.
  ***/
 
 /* Standard includes. */

--- a/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/readme.txt
+++ b/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/readme.txt
@@ -1,4 +1,4 @@
-See https://freertos.org/pkcs11/index.html for further information.
+See https://freertos.org/pkcs11/ for further information.
 
 Contains projects that demonstrate the PKCS #11 library.
 In order to run the mutual authentication demo, please convert the certificate and key PEM files associated with your IoT Thing, into a binary format DER.

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/core_pkcs11_config.h
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/core_pkcs11_config.h
@@ -65,7 +65,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Map the SdkLog macro to the logging function to enable logging
  * on Windows simulator. */
-#define SdkLog( message )    vLoggingPrintf message
+#ifndef SdkLog
+    #define SdkLog( message )    vLoggingPrintf message
+#endif
 
 #include "logging_stack.h"
 

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/core_pkcs11_config.h
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/core_pkcs11_config.h
@@ -56,43 +56,54 @@
     #define LIBRARY_LOG_LEVEL    LOG_ERROR
 #endif
 
+/* Prototype for the function used to print to console on Windows simulator
+ * of FreeRTOS.
+ * The function prints to the console before the network is connected;
+ * then a UDP port after the network has connected. */
+extern void vLoggingPrintf( const char * pcFormatString,
+                            ... );
+
+/* Map the SdkLog macro to the logging function to enable logging
+ * on Windows simulator. */
+#define SdkLog( message )    vLoggingPrintf message
+
 #include "logging_stack.h"
 
 /**
  * @brief Malloc API used by core_pkcs11.h
  */
-#define PKCS11_MALLOC pvPortMalloc
+#define PKCS11_MALLOC                                      pvPortMalloc
 
 /**
  * @brief Free API used by core_pkcs11.h
  */
-#define PKCS11_FREE vPortFree
+#define PKCS11_FREE                                        vPortFree
 
 /**
-* @brief PKCS #11 default user PIN.
-*
-* The PKCS #11 standard specifies the presence of a user PIN. That feature is
-* sensible for applications that have an interactive user interface and memory
-* protections. However, since typical microcontroller applications lack one or
-* both of those, the user PIN is assumed to be used herein for interoperability
-* purposes only, and not as a security feature.
-*
+ * @brief PKCS #11 default user PIN.
+ *
+ * The PKCS #11 standard specifies the presence of a user PIN. That feature is
+ * sensible for applications that have an interactive user interface and memory
+ * protections. However, since typical microcontroller applications lack one or
+ * both of those, the user PIN is assumed to be used herein for interoperability
+ * purposes only, and not as a security feature.
+ *
  * Note: Do not cast this to a pointer! The library calls sizeof to get the length
  * of this string.
-*/
-#define configPKCS11_DEFAULT_USER_PIN    "0000"
+ */
+#define configPKCS11_DEFAULT_USER_PIN                      "0000"
 
 /**
-* @brief Maximum length (in characters) for a PKCS #11 CKA_LABEL
-* attribute.
-*/
-#define pkcs11configMAX_LABEL_LENGTH     32
+ * @brief Maximum length (in characters) for a PKCS #11 CKA_LABEL
+ * attribute.
+ */
+#define pkcs11configMAX_LABEL_LENGTH                       32
 
 /**
-* @brief Maximum number of token objects that can be stored
-* by the PKCS #11 module.
-*/
-#define pkcs11configMAX_NUM_OBJECTS      6
+ * @brief Maximum number of token objects that can be stored
+ * by the PKCS #11 module.
+ */
+#define pkcs11configMAX_NUM_OBJECTS                        6
 
 /**
  * @brief Maximum number of sessions that can be stored
@@ -101,73 +112,73 @@
 #define pkcs11configMAX_SESSIONS                           10
 
 /**
-* @brief Set to 1 if a PAL destroy object is implemented.
-*
-* If set to 0, no PAL destroy object is implemented, and this functionality
-* is implemented in the common PKCS #11 layer.
-*/
+ * @brief Set to 1 if a PAL destroy object is implemented.
+ *
+ * If set to 0, no PAL destroy object is implemented, and this functionality
+ * is implemented in the common PKCS #11 layer.
+ */
 #define pkcs11configPAL_DESTROY_SUPPORTED                  0
 
 /**
-* @brief Set to 1 if OTA image verification via PKCS #11 module is supported.
-*
-* If set to 0, OTA code signing certificate is built in via
-* aws_ota_codesigner_certificate.h.
-*/
+ * @brief Set to 1 if OTA image verification via PKCS #11 module is supported.
+ *
+ * If set to 0, OTA code signing certificate is built in via
+ * aws_ota_codesigner_certificate.h.
+ */
 #define pkcs11configOTA_SUPPORTED                          0
 
 /**
-* @brief Set to 1 if PAL supports storage for JITP certificate,
-* code verify certificate, and trusted server root certificate.
-*
-* If set to 0, PAL does not support storage mechanism for these, and
-* they are accessed via headers compiled into the code.
-*/
+ * @brief Set to 1 if PAL supports storage for JITP certificate,
+ * code verify certificate, and trusted server root certificate.
+ *
+ * If set to 0, PAL does not support storage mechanism for these, and
+ * they are accessed via headers compiled into the code.
+ */
 #define pkcs11configJITP_CODEVERIFY_ROOT_CERT_SUPPORTED    0
 
 /**
-* @brief The PKCS #11 label for device private key.
-*
-* Private key for connection to AWS IoT endpoint.  The corresponding
-* public key should be registered with the AWS IoT endpoint.
-*/
+ * @brief The PKCS #11 label for device private key.
+ *
+ * Private key for connection to AWS IoT endpoint.  The corresponding
+ * public key should be registered with the AWS IoT endpoint.
+ */
 #define pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS       "Device Priv TLS Key"
 
 /**
-* @brief The PKCS #11 label for device public key.
-*
-* The public key corresponding to pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS.
-*/
+ * @brief The PKCS #11 label for device public key.
+ *
+ * The public key corresponding to pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS.
+ */
 #define pkcs11configLABEL_DEVICE_PUBLIC_KEY_FOR_TLS        "Device Pub TLS Key"
 
 /**
-* @brief The PKCS #11 label for the device certificate.
-*
-* Device certificate corresponding to pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS.
-*/
+ * @brief The PKCS #11 label for the device certificate.
+ *
+ * Device certificate corresponding to pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS.
+ */
 #define pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS       "Device Cert"
 
 /**
-* @brief The PKCS #11 label for the object to be used for code verification.
-*
-* Used by over-the-air update code to verify an incoming signed image.
-*/
+ * @brief The PKCS #11 label for the object to be used for code verification.
+ *
+ * Used by over-the-air update code to verify an incoming signed image.
+ */
 #define pkcs11configLABEL_CODE_VERIFICATION_KEY            "Code Verify Key"
 
 /**
-* @brief The PKCS #11 label for Just-In-Time-Provisioning.
-*
-* The certificate corresponding to the issuer of the device certificate
-* (pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS) when using the JITR or
-* JITP flow.
-*/
+ * @brief The PKCS #11 label for Just-In-Time-Provisioning.
+ *
+ * The certificate corresponding to the issuer of the device certificate
+ * (pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS) when using the JITR or
+ * JITP flow.
+ */
 #define pkcs11configLABEL_JITP_CERTIFICATE                 "JITP Cert"
 
 /**
-* @brief The PKCS #11 label for the AWS Trusted Root Certificate.
-*
-* @see aws_default_root_certificates.h
-*/
+ * @brief The PKCS #11 label for the AWS Trusted Root Certificate.
+ *
+ * @see aws_default_root_certificates.h
+ */
 #define pkcs11configLABEL_ROOT_CERTIFICATE                 "Root Cert"
 
 #endif /* _CORE_PKCS11_CONFIG_H_ */

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/main.c
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/main.c
@@ -26,7 +26,7 @@
  */
 
 /***
- * See https://www.FreeRTOS.org/pkcs11/index.html for configuration and usage instructions.
+ * See https://www.FreeRTOS.org/pkcs11/ for configuration and usage instructions.
  ***/
 
 /* Standard includes. */

--- a/FreeRTOS-Plus/Source/AWS/readme-device-shadow.url
+++ b/FreeRTOS-Plus/Source/AWS/readme-device-shadow.url
@@ -2,4 +2,4 @@
 Prop3=19,11
 [InternetShortcut]
 IDList=
-URL=https://www.freertos.org/mqtt/index.html
+URL=https://www.freertos.org/iot-device-shadow/index.html

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/sockets_wrapper.h
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/sockets_wrapper.h
@@ -62,7 +62,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Map the SdkLog macro to the logging function to enable logging
  * on Windows simulator. */
-#define SdkLog( message )    vLoggingPrintf message
+#ifndef SdkLog
+    #define SdkLog( message )    vLoggingPrintf message
+#endif
 
 #include "logging_stack.h"
 

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/sockets_wrapper.h
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/sockets_wrapper.h
@@ -53,6 +53,17 @@
     #define LIBRARY_LOG_LEVEL    LOG_ERROR
 #endif
 
+/* Prototype for the function used to print to console on Windows simulator
+ * of FreeRTOS.
+ * The function prints to the console before the network is connected;
+ * then a UDP port after the network has connected. */
+extern void vLoggingPrintf( const char * pcFormatString,
+                            ... );
+
+/* Map the SdkLog macro to the logging function to enable logging
+ * on Windows simulator. */
+#define SdkLog( message )    vLoggingPrintf message
+
 #include "logging_stack.h"
 
 /************ End of logging configuration ****************/

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/using_mbedtls/using_mbedtls.h
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/using_mbedtls/using_mbedtls.h
@@ -48,6 +48,17 @@
     #define LIBRARY_LOG_LEVEL    LOG_ERROR
 #endif
 
+/* Prototype for the function used to print to console on Windows simulator
+ * of FreeRTOS.
+ * The function prints to the console before the network is connected;
+ * then a UDP port after the network has connected. */
+extern void vLoggingPrintf( const char * pcFormatString,
+                            ... );
+
+/* Map the SdkLog macro to the logging function to enable logging
+ * on Windows simulator. */
+#define SdkLog( message )    vLoggingPrintf message
+
 #include "logging_stack.h"
 
 /************ End of logging configuration ****************/

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/using_mbedtls/using_mbedtls.h
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/using_mbedtls/using_mbedtls.h
@@ -57,7 +57,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Map the SdkLog macro to the logging function to enable logging
  * on Windows simulator. */
-#define SdkLog( message )    vLoggingPrintf message
+#ifndef SdkLog
+    #define SdkLog( message )    vLoggingPrintf message
+#endif
 
 #include "logging_stack.h"
 

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/using_mbedtls_pkcs11/using_mbedtls_pkcs11.h
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/using_mbedtls_pkcs11/using_mbedtls_pkcs11.h
@@ -60,7 +60,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Map the SdkLog macro to the logging function to enable logging
  * on Windows simulator. */
-#define SdkLog( message )    vLoggingPrintf message
+#ifndef SdkLog
+    #define SdkLog( message )    vLoggingPrintf message
+#endif
 
 #include "logging_stack.h"
 

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/using_mbedtls_pkcs11/using_mbedtls_pkcs11.h
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/using_mbedtls_pkcs11/using_mbedtls_pkcs11.h
@@ -51,6 +51,17 @@
     #define LIBRARY_LOG_LEVEL    LOG_ERROR
 #endif
 
+/* Prototype for the function used to print to console on Windows simulator
+ * of FreeRTOS.
+ * The function prints to the console before the network is connected;
+ * then a UDP port after the network has connected. */
+extern void vLoggingPrintf( const char * pcFormatString,
+                            ... );
+
+/* Map the SdkLog macro to the logging function to enable logging
+ * on Windows simulator. */
+#define SdkLog( message )    vLoggingPrintf message
+
 #include "logging_stack.h"
 
 /************ End of logging configuration ****************/

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/using_plaintext/using_plaintext.h
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/using_plaintext/using_plaintext.h
@@ -52,7 +52,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Map the SdkLog macro to the logging function to enable logging
  * on Windows simulator. */
-#define SdkLog( message )    vLoggingPrintf message
+#ifndef SdkLog
+    #define SdkLog( message )    vLoggingPrintf message
+#endif
 
 #include "logging_stack.h"
 

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/using_plaintext/using_plaintext.h
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/using_plaintext/using_plaintext.h
@@ -43,6 +43,17 @@
     #define LIBRARY_LOG_LEVEL    LOG_ERROR
 #endif
 
+/* Prototype for the function used to print to console on Windows simulator
+ * of FreeRTOS.
+ * The function prints to the console before the network is connected;
+ * then a UDP port after the network has connected. */
+extern void vLoggingPrintf( const char * pcFormatString,
+                            ... );
+
+/* Map the SdkLog macro to the logging function to enable logging
+ * on Windows simulator. */
+#define SdkLog( message )    vLoggingPrintf message
+
 #include "logging_stack.h"
 
 /************ End of logging configuration ****************/

--- a/FreeRTOS-Plus/Source/Utilities/logging/logging_levels.h
+++ b/FreeRTOS-Plus/Source/Utilities/logging/logging_levels.h
@@ -27,11 +27,11 @@
 
 /**
  * @file logging_levels.h
- * @brief Defines the logging level macros.
+ * @brief Defines the configuration constants for all logging verbosity levels.
  */
 
-#ifndef LOGGING_LEVELS_H_
-#define LOGGING_LEVELS_H_
+#ifndef LOGGING_LEVELS_H
+#define LOGGING_LEVELS_H
 
 /**
  * @constantspage{logging,logging library}
@@ -111,4 +111,4 @@
  */
 #define LOG_DEBUG    4
 
-#endif /* ifndef LOGGING_LEVELS_H_ */
+#endif /* ifndef LOGGING_LEVELS_H */

--- a/FreeRTOS-Plus/Source/Utilities/logging/logging_stack.h
+++ b/FreeRTOS-Plus/Source/Utilities/logging/logging_stack.h
@@ -27,35 +27,59 @@
 
 /**
  * @file logging_stack.h
- * @brief Reference implementation of Logging stack as a header-only library.
+ * @brief Utility header file that exposes macros for configuring logging implementation of logging macros (LogError, LogWarn, LogInfo, LogDebug).
  */
 
-#ifndef LOGGING_STACK_H_
-#define LOGGING_STACK_H_
+#ifndef LOGGING_STACK_H
+#define LOGGING_STACK_H
 
 /* Include header for logging level macros. */
 #include "logging_levels.h"
 
 /* Standard Include. */
+#include <stdio.h>
 #include <stdint.h>
 
+/**
+ * @brief The name of the library or demo to add as metadata in log messages
+ * from the library or demo.
+ *
+ * This metadata aids in identifying the module source of log messages.
+ * The metadata is logged in the format `[ <LIBRARY-NAME> ]` as a prefix to the
+ * log messages.
+ * Refer to #LOG_METADATA_FORMAT for the complete format of the metadata prefix in
+ * log messages.
+ */
+/* Check if LIBRARY_LOG_NAME macro has been defined. */
+#if !defined( LIBRARY_LOG_NAME )
+    #error "Please define LIBRARY_LOG_NAME for the library."
+#endif
+
 /* Metadata information to prepend to every log message. */
-#define LOG_METADATA_FORMAT    "[%s:%d] "
-#define LOG_METADATA_ARGS      __FUNCTION__, __LINE__
+#ifndef LOG_METADATA_FORMAT
+    #define LOG_METADATA_FORMAT    "[%s:%d] "                  /**< @brief Format of metadata prefix in log messages. */
+#endif
 
-/* Common macro for all logging interface macros. */
-#if !defined( DISABLE_LOGGING )
+#ifndef LOG_METADATA_ARGS
+    #define LOG_METADATA_ARGS    __FUNCTION__, __LINE__  /**< @brief Arguments into the metadata logging prefix format. */
+#endif
 
-/* Prototype for the function used to print out.  In this case it prints to the
- * console before the network is connected then a UDP port after the network has
- * connected. */
-    extern void vLoggingPrintf( const char * pcFormatString,
-                                ... );
-    #define SdkLog( string )    vLoggingPrintf string
-#else
+/**
+ * @brief Common macro that maps all the logging interfaces,
+ * (#LogDebug, #LogInfo, #LogWarn, #LogError) to the platform-specific logging
+ * function.
+ *
+ * @note The default definition of the macro is an empty definition that does not
+ * generate any logging.
+ */
+#ifndef SdkLog
     #define SdkLog( string )
 #endif
 
+/**
+ * Disable definition of logging interface macros when generating doxygen output,
+ * to avoid conflict with documentation of macros at the end of the file.
+ */
 /* Check that LIBRARY_LOG_LEVEL is defined and has a valid value. */
 #if !defined( LIBRARY_LOG_LEVEL ) ||       \
     ( ( LIBRARY_LOG_LEVEL != LOG_NONE ) && \
@@ -64,8 +88,6 @@
     ( LIBRARY_LOG_LEVEL != LOG_INFO ) &&   \
     ( LIBRARY_LOG_LEVEL != LOG_DEBUG ) )
     #error "Please define LIBRARY_LOG_LEVEL as either LOG_NONE, LOG_ERROR, LOG_WARN, LOG_INFO, or LOG_DEBUG."
-#elif !defined( LIBRARY_LOG_NAME )
-    #error "Please define LIBRARY_LOG_NAME for the library."
 #else
     #if LIBRARY_LOG_LEVEL == LOG_DEBUG
         /* All log level messages will logged. */
@@ -105,4 +127,4 @@
     #endif /* if LIBRARY_LOG_LEVEL == LOG_ERROR */
 #endif /* if !defined( LIBRARY_LOG_LEVEL ) || ( ( LIBRARY_LOG_LEVEL != LOG_NONE ) && ( LIBRARY_LOG_LEVEL != LOG_ERROR ) && ( LIBRARY_LOG_LEVEL != LOG_WARN ) && ( LIBRARY_LOG_LEVEL != LOG_INFO ) && ( LIBRARY_LOG_LEVEL != LOG_DEBUG ) ) */
 
-#endif /* ifndef LOGGING_STACK_H_ */
+#endif /* ifndef LOGGING_STACK_H */

--- a/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Networkless/Config/FreeRTOSConfig.h
+++ b/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Networkless/Config/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Networkless/Config/FreeRTOSIPConfig.h
+++ b/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Networkless/Config/FreeRTOSIPConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Networkless/Test_code/Test_Runner/test_runner.c
+++ b/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Networkless/Test_code/Test_Runner/test_runner.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS V202002.00
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Networkless/Test_code/Test_Runner/test_runner.h
+++ b/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Networkless/Test_code/Test_Runner/test_runner.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS V202002.00
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Networkless/WinPCap/arch.c
+++ b/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Networkless/WinPCap/arch.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Networkless/WinPCap/netif.h
+++ b/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Networkless/WinPCap/netif.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Suite/Config/FreeRTOSConfig.h
+++ b/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Suite/Config/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Suite/Config/FreeRTOSIPConfig.h
+++ b/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Suite/Config/FreeRTOSIPConfig.h
@@ -1,5 +1,5 @@
 /*
-FreeRTOS Kernel V10.4.1
+FreeRTOS V202011.00
 Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Suite/Test_Code/Test_Cases/include/application_version.h
+++ b/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Suite/Test_Code/Test_Cases/include/application_version.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS V202002.00
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Suite/Test_Code/Test_Cases/include/clientcredential.h
+++ b/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Suite/Test_Code/Test_Cases/include/clientcredential.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS V202002.00
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Suite/Test_Code/Test_Cases/include/config_common.h
+++ b/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Suite/Test_Code/Test_Cases/include/config_common.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS V202002.00
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Suite/Test_Code/Test_Cases/include/test_framework.h
+++ b/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Suite/Test_Code/Test_Cases/include/test_framework.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS V202002.00
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Suite/Test_Code/Test_Cases/include/test_runner.h
+++ b/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Suite/Test_Code/Test_Cases/include/test_runner.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS V202002.00
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Suite/Test_Code/Test_Cases/include/test_tcp.h
+++ b/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Suite/Test_Code/Test_Cases/include/test_tcp.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS V202002.00
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Suite/Test_Code/Test_Cases/include/test_utils.h
+++ b/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Suite/Test_Code/Test_Cases/include/test_utils.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS V202002.00
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Suite/Test_Code/Test_Cases/include/unity_config.h
+++ b/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Suite/Test_Code/Test_Cases/include/unity_config.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS V202002.00
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Suite/Test_Code/Test_Cases/test.c
+++ b/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Suite/Test_Code/Test_Cases/test.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS V202002.00
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Suite/Test_Code/Test_Cases/test_framework.c
+++ b/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Suite/Test_Code/Test_Cases/test_framework.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS V202002.00
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Suite/Test_Code/Test_Cases/test_freertos.c
+++ b/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Suite/Test_Code/Test_Cases/test_freertos.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS V202002.00
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Suite/Test_Code/Test_Runner/test_runner.c
+++ b/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Suite/Test_Code/Test_Runner/test_runner.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS V202002.00
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Suite/WinPCap/arch.c
+++ b/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Suite/WinPCap/arch.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Suite/WinPCap/netif.h
+++ b/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Suite/WinPCap/netif.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_AT91FR40008_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/ARM7_AT91FR40008_GCC/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_AT91FR40008_GCC/Makefile
+++ b/FreeRTOS/Demo/ARM7_AT91FR40008_GCC/Makefile
@@ -1,5 +1,5 @@
 #/*
-# * FreeRTOS Kernel V10.4.1
+# * FreeRTOS V202011.00
 # * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 # *
 # * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_AT91FR40008_GCC/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/ARM7_AT91FR40008_GCC/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_AT91FR40008_GCC/main.c
+++ b/FreeRTOS/Demo/ARM7_AT91FR40008_GCC/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_AT91FR40008_GCC/serial/serial.c
+++ b/FreeRTOS/Demo/ARM7_AT91FR40008_GCC/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_AT91FR40008_GCC/serial/serialISR.c
+++ b/FreeRTOS/Demo/ARM7_AT91FR40008_GCC/serial/serialISR.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_AT91SAM7S64_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/ARM7_AT91SAM7S64_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_AT91SAM7S64_IAR/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/ARM7_AT91SAM7S64_IAR/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_AT91SAM7S64_IAR/USB/USBSample.c
+++ b/FreeRTOS/Demo/ARM7_AT91SAM7S64_IAR/USB/USBSample.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_AT91SAM7S64_IAR/main.c
+++ b/FreeRTOS/Demo/ARM7_AT91SAM7S64_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_AT91SAM7S64_IAR/serial/serial.c
+++ b/FreeRTOS/Demo/ARM7_AT91SAM7S64_IAR/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2106_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/ARM7_LPC2106_GCC/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2106_GCC/Makefile
+++ b/FreeRTOS/Demo/ARM7_LPC2106_GCC/Makefile
@@ -1,5 +1,5 @@
 #/*
-# * FreeRTOS Kernel V10.4.1
+# * FreeRTOS V202011.00
 # * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 # *
 # * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2106_GCC/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/ARM7_LPC2106_GCC/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2106_GCC/main.c
+++ b/FreeRTOS/Demo/ARM7_LPC2106_GCC/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2106_GCC/serial/serial.c
+++ b/FreeRTOS/Demo/ARM7_LPC2106_GCC/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2106_GCC/serial/serialISR.c
+++ b/FreeRTOS/Demo/ARM7_LPC2106_GCC/serial/serialISR.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2129_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/ARM7_LPC2129_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2129_IAR/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/ARM7_LPC2129_IAR/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2129_IAR/main.c
+++ b/FreeRTOS/Demo/ARM7_LPC2129_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2129_IAR/serial/serial.c
+++ b/FreeRTOS/Demo/ARM7_LPC2129_IAR/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2129_Keil_RVDS/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/ARM7_LPC2129_Keil_RVDS/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2129_Keil_RVDS/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/ARM7_LPC2129_Keil_RVDS/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2129_Keil_RVDS/main.c
+++ b/FreeRTOS/Demo/ARM7_LPC2129_Keil_RVDS/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2129_Keil_RVDS/serial/serial.c
+++ b/FreeRTOS/Demo/ARM7_LPC2129_Keil_RVDS/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2129_Keil_RVDS/serial/serialISR.s
+++ b/FreeRTOS/Demo/ARM7_LPC2129_Keil_RVDS/serial/serialISR.s
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.4.1
+; * FreeRTOS V202011.00
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2138_Rowley/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/ARM7_LPC2138_Rowley/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2138_Rowley/main.c
+++ b/FreeRTOS/Demo/ARM7_LPC2138_Rowley/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2138_Rowley/mainISR.c
+++ b/FreeRTOS/Demo/ARM7_LPC2138_Rowley/mainISR.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2368_Eclipse/RTOSDemo/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/ARM7_LPC2368_Eclipse/RTOSDemo/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2368_Eclipse/RTOSDemo/Makefile
+++ b/FreeRTOS/Demo/ARM7_LPC2368_Eclipse/RTOSDemo/Makefile
@@ -1,5 +1,5 @@
 #/*
-# * FreeRTOS Kernel V10.4.1
+# * FreeRTOS V202011.00
 # * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 # *
 # * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2368_Eclipse/RTOSDemo/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/ARM7_LPC2368_Eclipse/RTOSDemo/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2368_Eclipse/RTOSDemo/main.c
+++ b/FreeRTOS/Demo/ARM7_LPC2368_Eclipse/RTOSDemo/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2368_Eclipse/RTOSDemo/webserver/uIP_Task.c
+++ b/FreeRTOS/Demo/ARM7_LPC2368_Eclipse/RTOSDemo/webserver/uIP_Task.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2368_Rowley/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/ARM7_LPC2368_Rowley/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2368_Rowley/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/ARM7_LPC2368_Rowley/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2368_Rowley/main.c
+++ b/FreeRTOS/Demo/ARM7_LPC2368_Rowley/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2368_Rowley/webserver/uIP_Task.c
+++ b/FreeRTOS/Demo/ARM7_LPC2368_Rowley/webserver/uIP_Task.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_STR71x_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/ARM7_STR71x_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_STR71x_IAR/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/ARM7_STR71x_IAR/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_STR71x_IAR/main.c
+++ b/FreeRTOS/Demo/ARM7_STR71x_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_STR71x_IAR/serial/serial.c
+++ b/FreeRTOS/Demo/ARM7_STR71x_IAR/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_STR75x_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/ARM7_STR75x_GCC/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_STR75x_GCC/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/ARM7_STR75x_GCC/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_STR75x_GCC/main.c
+++ b/FreeRTOS/Demo/ARM7_STR75x_GCC/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_STR75x_GCC/serial/serial.c
+++ b/FreeRTOS/Demo/ARM7_STR75x_GCC/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_STR75x_GCC/serial/serialISR.c
+++ b/FreeRTOS/Demo/ARM7_STR75x_GCC/serial/serialISR.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_STR75x_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/ARM7_STR75x_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_STR75x_IAR/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/ARM7_STR75x_IAR/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_STR75x_IAR/main.c
+++ b/FreeRTOS/Demo/ARM7_STR75x_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_STR75x_IAR/serial/serial.c
+++ b/FreeRTOS/Demo/ARM7_STR75x_IAR/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM9_AT91SAM9XE_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/ARM9_AT91SAM9XE_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM9_AT91SAM9XE_IAR/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/ARM9_AT91SAM9XE_IAR/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM9_AT91SAM9XE_IAR/main.c
+++ b/FreeRTOS/Demo/ARM9_AT91SAM9XE_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM9_AT91SAM9XE_IAR/serial/serial.c
+++ b/FreeRTOS/Demo/ARM9_AT91SAM9XE_IAR/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM9_STR91X_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/ARM9_STR91X_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM9_STR91X_IAR/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/ARM9_STR91X_IAR/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM9_STR91X_IAR/lwip/include/lwIPWebServer/BasicWEB.h
+++ b/FreeRTOS/Demo/ARM9_STR91X_IAR/lwip/include/lwIPWebServer/BasicWEB.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM9_STR91X_IAR/lwip/lwipWebServer/BasicWEB.c
+++ b/FreeRTOS/Demo/ARM9_STR91X_IAR/lwip/lwipWebServer/BasicWEB.c
@@ -1,6 +1,6 @@
 
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM9_STR91X_IAR/main.c
+++ b/FreeRTOS/Demo/ARM9_STR91X_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM9_STR91X_IAR/serial/serial.c
+++ b/FreeRTOS/Demo/ARM9_STR91X_IAR/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM9_STR91X_IAR/webserver/uIP_Task.c
+++ b/FreeRTOS/Demo/ARM9_STR91X_IAR/webserver/uIP_Task.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR32_UC3/main.c
+++ b/FreeRTOS/Demo/AVR32_UC3/main.c
@@ -30,7 +30,7 @@
  *****************************************************************************/
 
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATMega323_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/AVR_ATMega323_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATMega323_IAR/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/AVR_ATMega323_IAR/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATMega323_IAR/main.c
+++ b/FreeRTOS/Demo/AVR_ATMega323_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATMega323_IAR/regtest.c
+++ b/FreeRTOS/Demo/AVR_ATMega323_IAR/regtest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATMega323_IAR/regtest.h
+++ b/FreeRTOS/Demo/AVR_ATMega323_IAR/regtest.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATMega323_IAR/serial/serial.c
+++ b/FreeRTOS/Demo/AVR_ATMega323_IAR/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATMega323_WinAVR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/AVR_ATMega323_WinAVR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATMega323_WinAVR/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/AVR_ATMega323_WinAVR/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATMega323_WinAVR/main.c
+++ b/FreeRTOS/Demo/AVR_ATMega323_WinAVR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATMega323_WinAVR/regtest.c
+++ b/FreeRTOS/Demo/AVR_ATMega323_WinAVR/regtest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATMega323_WinAVR/regtest.h
+++ b/FreeRTOS/Demo/AVR_ATMega323_WinAVR/regtest.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATMega323_WinAVR/serial/serial.c
+++ b/FreeRTOS/Demo/AVR_ATMega323_WinAVR/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATMega4809_Atmel_Studio/RTOSDemo/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/AVR_ATMega4809_Atmel_Studio/RTOSDemo/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATMega4809_Atmel_Studio/RTOSDemo/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/AVR_ATMega4809_Atmel_Studio/RTOSDemo/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATMega4809_Atmel_Studio/RTOSDemo/main_blinky.c
+++ b/FreeRTOS/Demo/AVR_ATMega4809_Atmel_Studio/RTOSDemo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATMega4809_Atmel_Studio/RTOSDemo/regtest.c
+++ b/FreeRTOS/Demo/AVR_ATMega4809_Atmel_Studio/RTOSDemo/regtest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATMega4809_Atmel_Studio/RTOSDemo/regtest.h
+++ b/FreeRTOS/Demo/AVR_ATMega4809_Atmel_Studio/RTOSDemo/regtest.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATMega4809_Atmel_Studio/RTOSDemo/serial/serial.c
+++ b/FreeRTOS/Demo/AVR_ATMega4809_Atmel_Studio/RTOSDemo/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATMega4809_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/AVR_ATMega4809_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATMega4809_IAR/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/AVR_ATMega4809_IAR/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATMega4809_IAR/main_blinky.c
+++ b/FreeRTOS/Demo/AVR_ATMega4809_IAR/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATMega4809_IAR/regtest.c
+++ b/FreeRTOS/Demo/AVR_ATMega4809_IAR/regtest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATMega4809_IAR/regtest.h
+++ b/FreeRTOS/Demo/AVR_ATMega4809_IAR/regtest.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATMega4809_IAR/serial/serial.c
+++ b/FreeRTOS/Demo/AVR_ATMega4809_IAR/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATMega4809_MPLAB.X/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/AVR_ATMega4809_MPLAB.X/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATMega4809_MPLAB.X/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/AVR_ATMega4809_MPLAB.X/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATMega4809_MPLAB.X/main_blinky.c
+++ b/FreeRTOS/Demo/AVR_ATMega4809_MPLAB.X/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATMega4809_MPLAB.X/regtest.c
+++ b/FreeRTOS/Demo/AVR_ATMega4809_MPLAB.X/regtest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATMega4809_MPLAB.X/regtest.h
+++ b/FreeRTOS/Demo/AVR_ATMega4809_MPLAB.X/regtest.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATMega4809_MPLAB.X/serial/serial.c
+++ b/FreeRTOS/Demo/AVR_ATMega4809_MPLAB.X/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATmega328PB_Xplained_mini_GCC/RTOSDemo/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/AVR_ATmega328PB_Xplained_mini_GCC/RTOSDemo/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATmega328PB_Xplained_mini_GCC/RTOSDemo/ParTest.c
+++ b/FreeRTOS/Demo/AVR_ATmega328PB_Xplained_mini_GCC/RTOSDemo/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATmega328PB_Xplained_mini_GCC/RTOSDemo/main.c
+++ b/FreeRTOS/Demo/AVR_ATmega328PB_Xplained_mini_GCC/RTOSDemo/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATmega328PB_Xplained_mini_GCC/RTOSDemo/regtest.c
+++ b/FreeRTOS/Demo/AVR_ATmega328PB_Xplained_mini_GCC/RTOSDemo/regtest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATmega328PB_Xplained_mini_GCC/RTOSDemo/regtest.h
+++ b/FreeRTOS/Demo/AVR_ATmega328PB_Xplained_mini_GCC/RTOSDemo/regtest.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_Dx_Atmel_Studio/RTOSDemo/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/AVR_Dx_Atmel_Studio/RTOSDemo/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_Dx_Atmel_Studio/RTOSDemo/ParTest/partest.c
+++ b/FreeRTOS/Demo/AVR_Dx_Atmel_Studio/RTOSDemo/ParTest/partest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_Dx_Atmel_Studio/RTOSDemo/main_blinky.c
+++ b/FreeRTOS/Demo/AVR_Dx_Atmel_Studio/RTOSDemo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_Dx_Atmel_Studio/RTOSDemo/regtest.c
+++ b/FreeRTOS/Demo/AVR_Dx_Atmel_Studio/RTOSDemo/regtest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_Dx_Atmel_Studio/RTOSDemo/regtest.h
+++ b/FreeRTOS/Demo/AVR_Dx_Atmel_Studio/RTOSDemo/regtest.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_Dx_Atmel_Studio/RTOSDemo/serial/serial.c
+++ b/FreeRTOS/Demo/AVR_Dx_Atmel_Studio/RTOSDemo/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_Dx_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/AVR_Dx_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_Dx_IAR/ParTest/partest.c
+++ b/FreeRTOS/Demo/AVR_Dx_IAR/ParTest/partest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_Dx_IAR/RegTest.c
+++ b/FreeRTOS/Demo/AVR_Dx_IAR/RegTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_Dx_IAR/RegTest.h
+++ b/FreeRTOS/Demo/AVR_Dx_IAR/RegTest.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_Dx_IAR/main_blinky.c
+++ b/FreeRTOS/Demo/AVR_Dx_IAR/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_Dx_IAR/serial/serial.c
+++ b/FreeRTOS/Demo/AVR_Dx_IAR/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_Dx_MPLAB.X/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/AVR_Dx_MPLAB.X/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_Dx_MPLAB.X/ParTest/partest.c
+++ b/FreeRTOS/Demo/AVR_Dx_MPLAB.X/ParTest/partest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_Dx_MPLAB.X/RegTest.c
+++ b/FreeRTOS/Demo/AVR_Dx_MPLAB.X/RegTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_Dx_MPLAB.X/RegTest.h
+++ b/FreeRTOS/Demo/AVR_Dx_MPLAB.X/RegTest.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_Dx_MPLAB.X/main_blinky.c
+++ b/FreeRTOS/Demo/AVR_Dx_MPLAB.X/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_Dx_MPLAB.X/serial/serial.c
+++ b/FreeRTOS/Demo/AVR_Dx_MPLAB.X/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A2F200_IAR_and_Keil/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_A2F200_IAR_and_Keil/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A2F200_IAR_and_Keil/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_A2F200_IAR_and_Keil/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A2F200_IAR_and_Keil/main-blinky.c
+++ b/FreeRTOS/Demo/CORTEX_A2F200_IAR_and_Keil/main-blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A2F200_IAR_and_Keil/main-full.c
+++ b/FreeRTOS/Demo/CORTEX_A2F200_IAR_and_Keil/main-full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A2F200_IAR_and_Keil/uIP_Task.c
+++ b/FreeRTOS/Demo/CORTEX_A2F200_IAR_and_Keil/uIP_Task.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A2F200_SoftConsole/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_A2F200_SoftConsole/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A2F200_SoftConsole/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_A2F200_SoftConsole/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A2F200_SoftConsole/main-blinky.c
+++ b/FreeRTOS/Demo/CORTEX_A2F200_SoftConsole/main-blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A2F200_SoftConsole/main-full.c
+++ b/FreeRTOS/Demo/CORTEX_A2F200_SoftConsole/main-full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A2F200_SoftConsole/uIP_Task.c
+++ b/FreeRTOS/Demo/CORTEX_A2F200_SoftConsole/uIP_Task.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A53_64-bit_UltraScale_MPSoC/RTOSDemo_A53/src/Blinky_Demo/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_A53_64-bit_UltraScale_MPSoC/RTOSDemo_A53/src/Blinky_Demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A53_64-bit_UltraScale_MPSoC/RTOSDemo_A53/src/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_A53_64-bit_UltraScale_MPSoC/RTOSDemo_A53/src/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A53_64-bit_UltraScale_MPSoC/RTOSDemo_A53/src/FreeRTOS_tick_config.c
+++ b/FreeRTOS/Demo/CORTEX_A53_64-bit_UltraScale_MPSoC/RTOSDemo_A53/src/FreeRTOS_tick_config.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A53_64-bit_UltraScale_MPSoC/RTOSDemo_A53/src/Full_Demo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/CORTEX_A53_64-bit_UltraScale_MPSoC/RTOSDemo_A53/src/Full_Demo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A53_64-bit_UltraScale_MPSoC/RTOSDemo_A53/src/Full_Demo/IntQueueTimer.h
+++ b/FreeRTOS/Demo/CORTEX_A53_64-bit_UltraScale_MPSoC/RTOSDemo_A53/src/Full_Demo/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A53_64-bit_UltraScale_MPSoC/RTOSDemo_A53/src/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_A53_64-bit_UltraScale_MPSoC/RTOSDemo_A53/src/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A53_64-bit_UltraScale_MPSoC/RTOSDemo_A53/src/Full_Demo/reg_test.S
+++ b/FreeRTOS/Demo/CORTEX_A53_64-bit_UltraScale_MPSoC/RTOSDemo_A53/src/Full_Demo/reg_test.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A53_64-bit_UltraScale_MPSoC/RTOSDemo_A53/src/main.c
+++ b/FreeRTOS/Demo/CORTEX_A53_64-bit_UltraScale_MPSoC/RTOSDemo_A53/src/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D2x_Xplained_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D2x_Xplained_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D2x_Xplained_IAR/FreeRTOS_tick_config.c
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D2x_Xplained_IAR/FreeRTOS_tick_config.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D2x_Xplained_IAR/Full_Demo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D2x_Xplained_IAR/Full_Demo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D2x_Xplained_IAR/Full_Demo/IntQueueTimer.h
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D2x_Xplained_IAR/Full_Demo/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D2x_Xplained_IAR/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D2x_Xplained_IAR/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D2x_Xplained_IAR/Full_Demo/reg_test.S
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D2x_Xplained_IAR/Full_Demo/reg_test.S
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.4.1
+; * FreeRTOS V202011.00
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D2x_Xplained_IAR/LEDs.c
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D2x_Xplained_IAR/LEDs.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D2x_Xplained_IAR/blinky_demo/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D2x_Xplained_IAR/blinky_demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D2x_Xplained_IAR/main.c
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D2x_Xplained_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D3x_Xplained_IAR/CDCCommandConsole.c
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D3x_Xplained_IAR/CDCCommandConsole.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D3x_Xplained_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D3x_Xplained_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D3x_Xplained_IAR/FreeRTOS_tick_config.c
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D3x_Xplained_IAR/FreeRTOS_tick_config.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D3x_Xplained_IAR/Full_Demo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D3x_Xplained_IAR/Full_Demo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D3x_Xplained_IAR/Full_Demo/IntQueueTimer.h
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D3x_Xplained_IAR/Full_Demo/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D3x_Xplained_IAR/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D3x_Xplained_IAR/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D3x_Xplained_IAR/Full_Demo/reg_test.S
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D3x_Xplained_IAR/Full_Demo/reg_test.S
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.4.1
+; * FreeRTOS V202011.00
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D3x_Xplained_IAR/LEDs.c
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D3x_Xplained_IAR/LEDs.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D3x_Xplained_IAR/blinky_demo/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D3x_Xplained_IAR/blinky_demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D3x_Xplained_IAR/main.c
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D3x_Xplained_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D4x_EK_IAR/Blinky_Demo/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D4x_EK_IAR/Blinky_Demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D4x_EK_IAR/CDCCommandConsole.c
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D4x_EK_IAR/CDCCommandConsole.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D4x_EK_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D4x_EK_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D4x_EK_IAR/FreeRTOS_tick_config.c
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D4x_EK_IAR/FreeRTOS_tick_config.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D4x_EK_IAR/Full_Demo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D4x_EK_IAR/Full_Demo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D4x_EK_IAR/Full_Demo/IntQueueTimer.h
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D4x_EK_IAR/Full_Demo/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D4x_EK_IAR/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D4x_EK_IAR/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D4x_EK_IAR/Full_Demo/reg_test.S
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D4x_EK_IAR/Full_Demo/reg_test.S
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.4.1
+; * FreeRTOS V202011.00
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D4x_EK_IAR/LEDs.c
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D4x_EK_IAR/LEDs.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D4x_EK_IAR/main.c
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D4x_EK_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A9_Cyclone_V_SoC_DK/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_A9_Cyclone_V_SoC_DK/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A9_Cyclone_V_SoC_DK/LEDs.c
+++ b/FreeRTOS/Demo/CORTEX_A9_Cyclone_V_SoC_DK/LEDs.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A9_Cyclone_V_SoC_DK/main.c
+++ b/FreeRTOS/Demo/CORTEX_A9_Cyclone_V_SoC_DK/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A9_Cyclone_V_SoC_DK/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_A9_Cyclone_V_SoC_DK/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A9_Cyclone_V_SoC_DK/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_A9_Cyclone_V_SoC_DK/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A9_Cyclone_V_SoC_DK/reg_test.S
+++ b/FreeRTOS/Demo/CORTEX_A9_Cyclone_V_SoC_DK/reg_test.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A9_Cyclone_V_SoC_DK/serial.c
+++ b/FreeRTOS/Demo/CORTEX_A9_Cyclone_V_SoC_DK/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/Blinky_Demo/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/Blinky_Demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/FreeRTOS_tick_config.c
+++ b/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/FreeRTOS_tick_config.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/Full_Demo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/Full_Demo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/Full_Demo/IntQueueTimer.h
+++ b/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/Full_Demo/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/Full_Demo/reg_test.S
+++ b/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/Full_Demo/reg_test.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/Full_Demo/serial.c
+++ b/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/Full_Demo/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/lwIP_Demo/lwIP_Apps/apps/BasicSocketCommandServer/BasicSocketCommandServer.c
+++ b/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/lwIP_Demo/lwIP_Apps/apps/BasicSocketCommandServer/BasicSocketCommandServer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/lwIP_Demo/lwIP_Apps/lwIP_Apps.c
+++ b/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/lwIP_Demo/lwIP_Apps/lwIP_Apps.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/lwIP_Demo/lwIP_Apps/lwIP_Apps.h
+++ b/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/lwIP_Demo/lwIP_Apps/lwIP_Apps.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/lwIP_Demo/main_lwIP.c
+++ b/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/lwIP_Demo/main_lwIP.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/main.c
+++ b/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_AT91SAM3U256_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_AT91SAM3U256_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_AT91SAM3U256_IAR/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_AT91SAM3U256_IAR/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_AT91SAM3U256_IAR/lcd_message.h
+++ b/FreeRTOS/Demo/CORTEX_AT91SAM3U256_IAR/lcd_message.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_AT91SAM3U256_IAR/main.c
+++ b/FreeRTOS/Demo/CORTEX_AT91SAM3U256_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_AT91SAM3U256_IAR/serial/serial.c
+++ b/FreeRTOS/Demo/CORTEX_AT91SAM3U256_IAR/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_ATSAM3S-EK2_Atmel_Studio/src/Common-Demo-Source/comtest.c
+++ b/FreeRTOS/Demo/CORTEX_ATSAM3S-EK2_Atmel_Studio/src/Common-Demo-Source/comtest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_ATSAM3S-EK2_Atmel_Studio/src/Common-Demo-Source/include/demo_serial.h
+++ b/FreeRTOS/Demo/CORTEX_ATSAM3S-EK2_Atmel_Studio/src/Common-Demo-Source/include/demo_serial.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_ATSAM3S-EK2_Atmel_Studio/src/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_ATSAM3S-EK2_Atmel_Studio/src/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_ATSAM3S-EK2_Atmel_Studio/src/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_ATSAM3S-EK2_Atmel_Studio/src/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_ATSAM3S-EK2_Atmel_Studio/src/main.c
+++ b/FreeRTOS/Demo/CORTEX_ATSAM3S-EK2_Atmel_Studio/src/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_ATSAM3S-EK2_Atmel_Studio/src/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_ATSAM3S-EK2_Atmel_Studio/src/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_ATSAM3S-EK2_Atmel_Studio/src/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_ATSAM3S-EK2_Atmel_Studio/src/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_ATSAM3S-EK2_Atmel_Studio/src/serial.c
+++ b/FreeRTOS/Demo/CORTEX_ATSAM3S-EK2_Atmel_Studio/src/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_ATSAM3X_Atmel_Studio/src/Common-Demo-Source/comtest.c
+++ b/FreeRTOS/Demo/CORTEX_ATSAM3X_Atmel_Studio/src/Common-Demo-Source/comtest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_ATSAM3X_Atmel_Studio/src/Common-Demo-Source/include/demo_serial.h
+++ b/FreeRTOS/Demo/CORTEX_ATSAM3X_Atmel_Studio/src/Common-Demo-Source/include/demo_serial.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_ATSAM3X_Atmel_Studio/src/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_ATSAM3X_Atmel_Studio/src/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_ATSAM3X_Atmel_Studio/src/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_ATSAM3X_Atmel_Studio/src/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_ATSAM3X_Atmel_Studio/src/main.c
+++ b/FreeRTOS/Demo/CORTEX_ATSAM3X_Atmel_Studio/src/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_ATSAM3X_Atmel_Studio/src/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_ATSAM3X_Atmel_Studio/src/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_ATSAM3X_Atmel_Studio/src/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_ATSAM3X_Atmel_Studio/src/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_ATSAM3X_Atmel_Studio/src/serial.c
+++ b/FreeRTOS/Demo/CORTEX_ATSAM3X_Atmel_Studio/src/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_GCC/FreeRTOS_Demo.cydsn/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_GCC/FreeRTOS_Demo.cydsn/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_GCC/FreeRTOS_Demo.cydsn/IntQueueTimer.c
+++ b/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_GCC/FreeRTOS_Demo.cydsn/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_GCC/FreeRTOS_Demo.cydsn/IntQueueTimer.h
+++ b/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_GCC/FreeRTOS_Demo.cydsn/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_GCC/FreeRTOS_Demo.cydsn/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_GCC/FreeRTOS_Demo.cydsn/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_GCC/FreeRTOS_Demo.cydsn/Serial.c
+++ b/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_GCC/FreeRTOS_Demo.cydsn/Serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_GCC/FreeRTOS_Demo.cydsn/TimerTest.c
+++ b/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_GCC/FreeRTOS_Demo.cydsn/TimerTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_GCC/FreeRTOS_Demo.cydsn/main.c
+++ b/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_GCC/FreeRTOS_Demo.cydsn/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_Keil/FreeRTOS_Demo.cydsn/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_Keil/FreeRTOS_Demo.cydsn/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_Keil/FreeRTOS_Demo.cydsn/IntQueueTimer.c
+++ b/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_Keil/FreeRTOS_Demo.cydsn/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_Keil/FreeRTOS_Demo.cydsn/IntQueueTimer.h
+++ b/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_Keil/FreeRTOS_Demo.cydsn/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_Keil/FreeRTOS_Demo.cydsn/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_Keil/FreeRTOS_Demo.cydsn/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_Keil/FreeRTOS_Demo.cydsn/Serial.c
+++ b/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_Keil/FreeRTOS_Demo.cydsn/Serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_Keil/FreeRTOS_Demo.cydsn/TimerTest.c
+++ b/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_Keil/FreeRTOS_Demo.cydsn/TimerTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_Keil/FreeRTOS_Demo.cydsn/main.c
+++ b/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_Keil/FreeRTOS_Demo.cydsn/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_RVDS/FreeRTOS_Demo.cydsn/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_RVDS/FreeRTOS_Demo.cydsn/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_RVDS/FreeRTOS_Demo.cydsn/IntQueueTimer.c
+++ b/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_RVDS/FreeRTOS_Demo.cydsn/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_RVDS/FreeRTOS_Demo.cydsn/IntQueueTimer.h
+++ b/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_RVDS/FreeRTOS_Demo.cydsn/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_RVDS/FreeRTOS_Demo.cydsn/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_RVDS/FreeRTOS_Demo.cydsn/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_RVDS/FreeRTOS_Demo.cydsn/Serial.c
+++ b/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_RVDS/FreeRTOS_Demo.cydsn/Serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_RVDS/FreeRTOS_Demo.cydsn/TimerTest.c
+++ b/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_RVDS/FreeRTOS_Demo.cydsn/TimerTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_RVDS/FreeRTOS_Demo.cydsn/main.c
+++ b/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_RVDS/FreeRTOS_Demo.cydsn/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_EFM32_Giant_Gecko_Simplicity_Studio/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_EFM32_Giant_Gecko_Simplicity_Studio/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_EFM32_Giant_Gecko_Simplicity_Studio/Full_Demo/RegTest.c
+++ b/FreeRTOS/Demo/CORTEX_EFM32_Giant_Gecko_Simplicity_Studio/Full_Demo/RegTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_EFM32_Giant_Gecko_Simplicity_Studio/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_EFM32_Giant_Gecko_Simplicity_Studio/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_EFM32_Giant_Gecko_Simplicity_Studio/Low_Power_Demo/low_power_tick_management_BURTC.c
+++ b/FreeRTOS/Demo/CORTEX_EFM32_Giant_Gecko_Simplicity_Studio/Low_Power_Demo/low_power_tick_management_BURTC.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_EFM32_Giant_Gecko_Simplicity_Studio/Low_Power_Demo/low_power_tick_management_RTC.c
+++ b/FreeRTOS/Demo/CORTEX_EFM32_Giant_Gecko_Simplicity_Studio/Low_Power_Demo/low_power_tick_management_RTC.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_EFM32_Giant_Gecko_Simplicity_Studio/Low_Power_Demo/main_low_power.c
+++ b/FreeRTOS/Demo/CORTEX_EFM32_Giant_Gecko_Simplicity_Studio/Low_Power_Demo/main_low_power.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_EFM32_Giant_Gecko_Simplicity_Studio/main.c
+++ b/FreeRTOS/Demo/CORTEX_EFM32_Giant_Gecko_Simplicity_Studio/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_EFM32_Pearl_Gecko_Simplicity_Studio/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_EFM32_Pearl_Gecko_Simplicity_Studio/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_EFM32_Pearl_Gecko_Simplicity_Studio/Full_Demo/RegTest.c
+++ b/FreeRTOS/Demo/CORTEX_EFM32_Pearl_Gecko_Simplicity_Studio/Full_Demo/RegTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_EFM32_Pearl_Gecko_Simplicity_Studio/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_EFM32_Pearl_Gecko_Simplicity_Studio/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_EFM32_Pearl_Gecko_Simplicity_Studio/Low_Power_Demo/low_power_tick_management_RTCC.c
+++ b/FreeRTOS/Demo/CORTEX_EFM32_Pearl_Gecko_Simplicity_Studio/Low_Power_Demo/low_power_tick_management_RTCC.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_EFM32_Pearl_Gecko_Simplicity_Studio/Low_Power_Demo/main_low_power.c
+++ b/FreeRTOS/Demo/CORTEX_EFM32_Pearl_Gecko_Simplicity_Studio/Low_Power_Demo/main_low_power.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_EFM32_Pearl_Gecko_Simplicity_Studio/main.c
+++ b/FreeRTOS/Demo/CORTEX_EFM32_Pearl_Gecko_Simplicity_Studio/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_Kinetis_K60_Tower_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_Kinetis_K60_Tower_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_Kinetis_K60_Tower_IAR/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_Kinetis_K60_Tower_IAR/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_Kinetis_K60_Tower_IAR/main-full.c
+++ b/FreeRTOS/Demo/CORTEX_Kinetis_K60_Tower_IAR/main-full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_Kinetis_K60_Tower_IAR/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_Kinetis_K60_Tower_IAR/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_Kinetis_K60_Tower_IAR/uIP_Task.c
+++ b/FreeRTOS/Demo/CORTEX_Kinetis_K60_Tower_IAR/uIP_Task.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_Kinetis_K60_Tower_IAR/webserver/EMAC.c
+++ b/FreeRTOS/Demo/CORTEX_Kinetis_K60_Tower_IAR/webserver/EMAC.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_Kinetis_K60_Tower_IAR/webserver/EMAC.h
+++ b/FreeRTOS/Demo/CORTEX_Kinetis_K60_Tower_IAR/webserver/EMAC.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S102_GCC/Demo1/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_LM3S102_GCC/Demo1/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S102_GCC/Demo1/main.c
+++ b/FreeRTOS/Demo/CORTEX_LM3S102_GCC/Demo1/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S102_GCC/Demo2/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_LM3S102_GCC/Demo2/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S102_GCC/Demo2/main.c
+++ b/FreeRTOS/Demo/CORTEX_LM3S102_GCC/Demo2/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S102_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_LM3S102_GCC/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S102_GCC/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_LM3S102_GCC/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S102_GCC/main.c
+++ b/FreeRTOS/Demo/CORTEX_LM3S102_GCC/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S102_Rowley/Demo1/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_LM3S102_Rowley/Demo1/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S102_Rowley/Demo1/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_LM3S102_Rowley/Demo1/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S102_Rowley/Demo1/main.c
+++ b/FreeRTOS/Demo/CORTEX_LM3S102_Rowley/Demo1/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S102_Rowley/Demo2/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_LM3S102_Rowley/Demo2/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S102_Rowley/Demo2/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_LM3S102_Rowley/Demo2/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S102_Rowley/Demo2/main.c
+++ b/FreeRTOS/Demo/CORTEX_LM3S102_Rowley/Demo2/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S102_Rowley/Demo3/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_LM3S102_Rowley/Demo3/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S102_Rowley/Demo3/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_LM3S102_Rowley/Demo3/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S102_Rowley/Demo3/main.c
+++ b/FreeRTOS/Demo/CORTEX_LM3S102_Rowley/Demo3/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S316_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_LM3S316_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S316_IAR/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_LM3S316_IAR/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S316_IAR/commstest.c
+++ b/FreeRTOS/Demo/CORTEX_LM3S316_IAR/commstest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S316_IAR/commstest.h
+++ b/FreeRTOS/Demo/CORTEX_LM3S316_IAR/commstest.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S316_IAR/main.c
+++ b/FreeRTOS/Demo/CORTEX_LM3S316_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S6965_GCC_QEMU/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_LM3S6965_GCC_QEMU/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S6965_GCC_QEMU/LocalDemoFiles/IntQueueTimer.c
+++ b/FreeRTOS/Demo/CORTEX_LM3S6965_GCC_QEMU/LocalDemoFiles/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S6965_GCC_QEMU/LocalDemoFiles/IntQueueTimer.h
+++ b/FreeRTOS/Demo/CORTEX_LM3S6965_GCC_QEMU/LocalDemoFiles/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S6965_GCC_QEMU/LocalDemoFiles/timertest.c
+++ b/FreeRTOS/Demo/CORTEX_LM3S6965_GCC_QEMU/LocalDemoFiles/timertest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S6965_GCC_QEMU/main.c
+++ b/FreeRTOS/Demo/CORTEX_LM3S6965_GCC_QEMU/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S811_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_LM3S811_GCC/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S811_GCC/main.c
+++ b/FreeRTOS/Demo/CORTEX_LM3S811_GCC/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S811_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_LM3S811_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S811_IAR/main.c
+++ b/FreeRTOS/Demo/CORTEX_LM3S811_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S811_KEIL/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_LM3S811_KEIL/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S811_KEIL/heap/heap_1.c
+++ b/FreeRTOS/Demo/CORTEX_LM3S811_KEIL/heap/heap_1.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S811_KEIL/main.c
+++ b/FreeRTOS/Demo/CORTEX_LM3S811_KEIL/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3Sxxxx_IAR_Keil/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_LM3Sxxxx_IAR_Keil/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3Sxxxx_IAR_Keil/IntQueueTimer.c
+++ b/FreeRTOS/Demo/CORTEX_LM3Sxxxx_IAR_Keil/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3Sxxxx_IAR_Keil/IntQueueTimer.h
+++ b/FreeRTOS/Demo/CORTEX_LM3Sxxxx_IAR_Keil/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3Sxxxx_IAR_Keil/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_LM3Sxxxx_IAR_Keil/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3Sxxxx_IAR_Keil/main.c
+++ b/FreeRTOS/Demo/CORTEX_LM3Sxxxx_IAR_Keil/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3Sxxxx_IAR_Keil/timertest.c
+++ b/FreeRTOS/Demo/CORTEX_LM3Sxxxx_IAR_Keil/timertest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3Sxxxx_IAR_Keil/webserver/emac.c
+++ b/FreeRTOS/Demo/CORTEX_LM3Sxxxx_IAR_Keil/webserver/emac.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3Sxxxx_IAR_Keil/webserver/uIP_Task.c
+++ b/FreeRTOS/Demo/CORTEX_LM3Sxxxx_IAR_Keil/webserver/uIP_Task.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3Sxxxx_Rowley/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_LM3Sxxxx_Rowley/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3Sxxxx_Rowley/IntQueueTimer.c
+++ b/FreeRTOS/Demo/CORTEX_LM3Sxxxx_Rowley/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3Sxxxx_Rowley/IntQueueTimer.h
+++ b/FreeRTOS/Demo/CORTEX_LM3Sxxxx_Rowley/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3Sxxxx_Rowley/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_LM3Sxxxx_Rowley/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3Sxxxx_Rowley/main.c
+++ b/FreeRTOS/Demo/CORTEX_LM3Sxxxx_Rowley/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3Sxxxx_Rowley/timertest.c
+++ b/FreeRTOS/Demo/CORTEX_LM3Sxxxx_Rowley/timertest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3Sxxxx_Rowley/webserver/emac.c
+++ b/FreeRTOS/Demo/CORTEX_LM3Sxxxx_Rowley/webserver/emac.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3Sxxxx_Rowley/webserver/uIP_Task.c
+++ b/FreeRTOS/Demo/CORTEX_LM3Sxxxx_Rowley/webserver/uIP_Task.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LPC1768_GCC_RedSuite/src/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_LPC1768_GCC_RedSuite/src/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LPC1768_GCC_RedSuite/src/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_LPC1768_GCC_RedSuite/src/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LPC1768_GCC_RedSuite/src/main.c
+++ b/FreeRTOS/Demo/CORTEX_LPC1768_GCC_RedSuite/src/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LPC1768_GCC_RedSuite/src/webserver/emac.c
+++ b/FreeRTOS/Demo/CORTEX_LPC1768_GCC_RedSuite/src/webserver/emac.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LPC1768_GCC_RedSuite/src/webserver/uIP_Task.c
+++ b/FreeRTOS/Demo/CORTEX_LPC1768_GCC_RedSuite/src/webserver/uIP_Task.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LPC1768_GCC_Rowley/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_LPC1768_GCC_Rowley/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LPC1768_GCC_Rowley/LED.h
+++ b/FreeRTOS/Demo/CORTEX_LPC1768_GCC_Rowley/LED.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LPC1768_GCC_Rowley/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_LPC1768_GCC_Rowley/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LPC1768_GCC_Rowley/main.c
+++ b/FreeRTOS/Demo/CORTEX_LPC1768_GCC_Rowley/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LPC1768_GCC_Rowley/webserver/emac.c
+++ b/FreeRTOS/Demo/CORTEX_LPC1768_GCC_Rowley/webserver/emac.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LPC1768_GCC_Rowley/webserver/uIP_Task.c
+++ b/FreeRTOS/Demo/CORTEX_LPC1768_GCC_Rowley/webserver/uIP_Task.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LPC1768_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_LPC1768_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LPC1768_IAR/LED.h
+++ b/FreeRTOS/Demo/CORTEX_LPC1768_IAR/LED.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LPC1768_IAR/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_LPC1768_IAR/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LPC1768_IAR/main.c
+++ b/FreeRTOS/Demo/CORTEX_LPC1768_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LPC1768_IAR/webserver/emac.c
+++ b/FreeRTOS/Demo/CORTEX_LPC1768_IAR/webserver/emac.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LPC1768_IAR/webserver/uIP_Task.c
+++ b/FreeRTOS/Demo/CORTEX_LPC1768_IAR/webserver/uIP_Task.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0+_Atmel_SAMD20_XPlained/RTOSDemo/src/RegTest.c
+++ b/FreeRTOS/Demo/CORTEX_M0+_Atmel_SAMD20_XPlained/RTOSDemo/src/RegTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0+_Atmel_SAMD20_XPlained/RTOSDemo/src/Sample-CLI-commands.c
+++ b/FreeRTOS/Demo/CORTEX_M0+_Atmel_SAMD20_XPlained/RTOSDemo/src/Sample-CLI-commands.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0+_Atmel_SAMD20_XPlained/RTOSDemo/src/UARTCommandConsole.c
+++ b/FreeRTOS/Demo/CORTEX_M0+_Atmel_SAMD20_XPlained/RTOSDemo/src/UARTCommandConsole.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0+_Atmel_SAMD20_XPlained/RTOSDemo/src/UARTCommandConsole.h
+++ b/FreeRTOS/Demo/CORTEX_M0+_Atmel_SAMD20_XPlained/RTOSDemo/src/UARTCommandConsole.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0+_Atmel_SAMD20_XPlained/RTOSDemo/src/config/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M0+_Atmel_SAMD20_XPlained/RTOSDemo/src/config/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0+_Atmel_SAMD20_XPlained/RTOSDemo/src/main-blinky.c
+++ b/FreeRTOS/Demo/CORTEX_M0+_Atmel_SAMD20_XPlained/RTOSDemo/src/main-blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0+_Atmel_SAMD20_XPlained/RTOSDemo/src/main-full.c
+++ b/FreeRTOS/Demo/CORTEX_M0+_Atmel_SAMD20_XPlained/RTOSDemo/src/main-full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0+_Atmel_SAMD20_XPlained/RTOSDemo/src/main.c
+++ b/FreeRTOS/Demo/CORTEX_M0+_Atmel_SAMD20_XPlained/RTOSDemo/src/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0+_LPC51U68_GCC_IAR_KEIL/GCC_specific/RegTest.c
+++ b/FreeRTOS/Demo/CORTEX_M0+_LPC51U68_GCC_IAR_KEIL/GCC_specific/RegTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0+_LPC51U68_GCC_IAR_KEIL/GCC_specific/compiler_attributes.h
+++ b/FreeRTOS/Demo/CORTEX_M0+_LPC51U68_GCC_IAR_KEIL/GCC_specific/compiler_attributes.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0+_LPC51U68_GCC_IAR_KEIL/IAR_specific/RegTest_IAR.s
+++ b/FreeRTOS/Demo/CORTEX_M0+_LPC51U68_GCC_IAR_KEIL/IAR_specific/RegTest_IAR.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0+_LPC51U68_GCC_IAR_KEIL/IAR_specific/compiler_attributes.h
+++ b/FreeRTOS/Demo/CORTEX_M0+_LPC51U68_GCC_IAR_KEIL/IAR_specific/compiler_attributes.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0+_LPC51U68_GCC_IAR_KEIL/Keil_specific/RegTest_Keil.s
+++ b/FreeRTOS/Demo/CORTEX_M0+_LPC51U68_GCC_IAR_KEIL/Keil_specific/RegTest_Keil.s
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.4.1
+; * FreeRTOS V202011.00
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0+_LPC51U68_GCC_IAR_KEIL/Keil_specific/compiler_attributes.h
+++ b/FreeRTOS/Demo/CORTEX_M0+_LPC51U68_GCC_IAR_KEIL/Keil_specific/compiler_attributes.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0+_LPC51U68_GCC_IAR_KEIL/app/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M0+_LPC51U68_GCC_IAR_KEIL/app/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0+_LPC51U68_GCC_IAR_KEIL/app/IntQueueTimer.c
+++ b/FreeRTOS/Demo/CORTEX_M0+_LPC51U68_GCC_IAR_KEIL/app/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0+_LPC51U68_GCC_IAR_KEIL/app/IntQueueTimer.h
+++ b/FreeRTOS/Demo/CORTEX_M0+_LPC51U68_GCC_IAR_KEIL/app/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0+_LPC51U68_GCC_IAR_KEIL/app/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_M0+_LPC51U68_GCC_IAR_KEIL/app/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0+_LPC51U68_GCC_IAR_KEIL/app/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_M0+_LPC51U68_GCC_IAR_KEIL/app/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0_Infineon_XMC1000_IAR_Keil_GCC/Atollic_Specific/RegTest.c
+++ b/FreeRTOS/Demo/CORTEX_M0_Infineon_XMC1000_IAR_Keil_GCC/Atollic_Specific/RegTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0_Infineon_XMC1000_IAR_Keil_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M0_Infineon_XMC1000_IAR_Keil_GCC/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0_Infineon_XMC1000_IAR_Keil_GCC/IAR_Specific/RegTest_IAR.s
+++ b/FreeRTOS/Demo/CORTEX_M0_Infineon_XMC1000_IAR_Keil_GCC/IAR_Specific/RegTest_IAR.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0_Infineon_XMC1000_IAR_Keil_GCC/Keil_Specific/RegTest_Keil.s
+++ b/FreeRTOS/Demo/CORTEX_M0_Infineon_XMC1000_IAR_Keil_GCC/Keil_Specific/RegTest_Keil.s
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.4.1
+; * FreeRTOS V202011.00
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0_Infineon_XMC1000_IAR_Keil_GCC/ParTest_XMC1100.c
+++ b/FreeRTOS/Demo/CORTEX_M0_Infineon_XMC1000_IAR_Keil_GCC/ParTest_XMC1100.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0_Infineon_XMC1000_IAR_Keil_GCC/ParTest_XMC1200.c
+++ b/FreeRTOS/Demo/CORTEX_M0_Infineon_XMC1000_IAR_Keil_GCC/ParTest_XMC1200.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0_Infineon_XMC1000_IAR_Keil_GCC/ParTest_XMC1300.c
+++ b/FreeRTOS/Demo/CORTEX_M0_Infineon_XMC1000_IAR_Keil_GCC/ParTest_XMC1300.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0_Infineon_XMC1000_IAR_Keil_GCC/main-blinky.c
+++ b/FreeRTOS/Demo/CORTEX_M0_Infineon_XMC1000_IAR_Keil_GCC/main-blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0_Infineon_XMC1000_IAR_Keil_GCC/main-full.c
+++ b/FreeRTOS/Demo/CORTEX_M0_Infineon_XMC1000_IAR_Keil_GCC/main-full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0_Infineon_XMC1000_IAR_Keil_GCC/main.c
+++ b/FreeRTOS/Demo/CORTEX_M0_Infineon_XMC1000_IAR_Keil_GCC/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0_LPC1114_LPCXpresso/RTOSDemo/Source/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M0_LPC1114_LPCXpresso/RTOSDemo/Source/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0_LPC1114_LPCXpresso/RTOSDemo/Source/IntQueueTimer.c
+++ b/FreeRTOS/Demo/CORTEX_M0_LPC1114_LPCXpresso/RTOSDemo/Source/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0_LPC1114_LPCXpresso/RTOSDemo/Source/IntQueueTimer.h
+++ b/FreeRTOS/Demo/CORTEX_M0_LPC1114_LPCXpresso/RTOSDemo/Source/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0_LPC1114_LPCXpresso/RTOSDemo/Source/RegTest.c
+++ b/FreeRTOS/Demo/CORTEX_M0_LPC1114_LPCXpresso/RTOSDemo/Source/RegTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0_LPC1114_LPCXpresso/RTOSDemo/Source/main-blinky.c
+++ b/FreeRTOS/Demo/CORTEX_M0_LPC1114_LPCXpresso/RTOSDemo/Source/main-blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0_LPC1114_LPCXpresso/RTOSDemo/Source/main-full.c
+++ b/FreeRTOS/Demo/CORTEX_M0_LPC1114_LPCXpresso/RTOSDemo/Source/main-full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0_LPC1114_LPCXpresso/RTOSDemo/Source/main.c
+++ b/FreeRTOS/Demo/CORTEX_M0_LPC1114_LPCXpresso/RTOSDemo/Source/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0_STM32F0518_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M0_STM32F0518_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0_STM32F0518_IAR/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_M0_STM32F0518_IAR/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0_STM32F0518_IAR/RegTest.s
+++ b/FreeRTOS/Demo/CORTEX_M0_STM32F0518_IAR/RegTest.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0_STM32F0518_IAR/main-blinky.c
+++ b/FreeRTOS/Demo/CORTEX_M0_STM32F0518_IAR/main-blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0_STM32F0518_IAR/main-full.c
+++ b/FreeRTOS/Demo/CORTEX_M0_STM32F0518_IAR/main-full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0_STM32F0518_IAR/main.c
+++ b/FreeRTOS/Demo/CORTEX_M0_STM32F0518_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/init/startup.c
+++ b/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/init/startup.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/main.c
+++ b/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/scripts/mps2_m3.ld
+++ b/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/scripts/mps2_m3.ld
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/syscall.c
+++ b/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/syscall.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_CEC1302_Keil_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M4F_CEC1302_Keil_GCC/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_CEC1302_Keil_GCC/GCC_Specific/RegTest.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_CEC1302_Keil_GCC/GCC_Specific/RegTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_CEC1302_Keil_GCC/Keil_Specific/RegTest.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_CEC1302_Keil_GCC/Keil_Specific/RegTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_CEC1302_Keil_GCC/main.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_CEC1302_Keil_GCC/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_CEC1302_Keil_GCC/main_full/IntQueueTimer.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_CEC1302_Keil_GCC/main_full/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_CEC1302_Keil_GCC/main_full/IntQueueTimer.h
+++ b/FreeRTOS/Demo/CORTEX_M4F_CEC1302_Keil_GCC/main_full/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_CEC1302_Keil_GCC/main_full/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_CEC1302_Keil_GCC/main_full/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_CEC1302_Keil_GCC/main_low_power/low_power_tick_config.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_CEC1302_Keil_GCC/main_low_power/low_power_tick_config.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_CEC1302_Keil_GCC/main_low_power/main_low_power.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_CEC1302_Keil_GCC/main_low_power/main_low_power.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_CEC1302_MikroC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M4F_CEC1302_MikroC/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_CEC1302_MikroC/MikroC_Specific/RegTest.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_CEC1302_MikroC/MikroC_Specific/RegTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_CEC1302_MikroC/main.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_CEC1302_MikroC/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_CEC1302_MikroC/main_full/IntQueueTimer.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_CEC1302_MikroC/main_full/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_CEC1302_MikroC/main_full/IntQueueTimer.h
+++ b/FreeRTOS/Demo/CORTEX_M4F_CEC1302_MikroC/main_full/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_CEC1302_MikroC/main_full/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_CEC1302_MikroC/main_full/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_CEC1302_MikroC/main_low_power/low_power_tick_config.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_CEC1302_MikroC/main_low_power/low_power_tick_config.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_CEC1302_MikroC/main_low_power/main_low_power.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_CEC1302_MikroC/main_low_power/main_low_power.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_CEC_MEC_17xx_51xx_Keil_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M4F_CEC_MEC_17xx_51xx_Keil_GCC/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_CEC_MEC_17xx_51xx_Keil_GCC/main.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_CEC_MEC_17xx_51xx_Keil_GCC/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_GCC_Dave/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_GCC_Dave/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_GCC_Dave/main.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_GCC_Dave/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_GCC_Dave/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_GCC_Dave/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_GCC_Dave/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_GCC_Dave/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_IAR/RegTest.s
+++ b/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_IAR/RegTest.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_IAR/main.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_IAR/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_IAR/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_IAR/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_IAR/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_Keil/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_Keil/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_Keil/RegTest.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_Keil/RegTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_Keil/main.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_Keil/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_Keil/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_Keil/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_Keil/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_Keil/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_Tasking/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_Tasking/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_Tasking/main.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_Tasking/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_Tasking/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_Tasking/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_Tasking/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_Tasking/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4500_GCC_Atollic/src/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4500_GCC_Atollic/src/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4500_GCC_Atollic/src/main.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4500_GCC_Atollic/src/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4500_GCC_Atollic/src/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4500_GCC_Atollic/src/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4500_GCC_Atollic/src/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4500_GCC_Atollic/src/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_M0_LPC43xx_Keil/M4/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M4F_M0_LPC43xx_Keil/M4/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_M0_LPC43xx_Keil/M4/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_M0_LPC43xx_Keil/M4/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_M0_LPC43xx_Keil/M4/RegTest.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_M0_LPC43xx_Keil/M4/RegTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_M0_LPC43xx_Keil/M4/main.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_M0_LPC43xx_Keil/M4/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_MSP432_LaunchPad_IAR_CCS_Keil/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M4F_MSP432_LaunchPad_IAR_CCS_Keil/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_MSP432_LaunchPad_IAR_CCS_Keil/Full_Demo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_MSP432_LaunchPad_IAR_CCS_Keil/Full_Demo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_MSP432_LaunchPad_IAR_CCS_Keil/Full_Demo/IntQueueTimer.h
+++ b/FreeRTOS/Demo/CORTEX_M4F_MSP432_LaunchPad_IAR_CCS_Keil/Full_Demo/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_MSP432_LaunchPad_IAR_CCS_Keil/Full_Demo/RegTest.asm
+++ b/FreeRTOS/Demo/CORTEX_M4F_MSP432_LaunchPad_IAR_CCS_Keil/Full_Demo/RegTest.asm
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.4.1
+; * FreeRTOS V202011.00
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_MSP432_LaunchPad_IAR_CCS_Keil/Full_Demo/RegTest.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_MSP432_LaunchPad_IAR_CCS_Keil/Full_Demo/RegTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_MSP432_LaunchPad_IAR_CCS_Keil/Full_Demo/RegTest.s
+++ b/FreeRTOS/Demo/CORTEX_M4F_MSP432_LaunchPad_IAR_CCS_Keil/Full_Demo/RegTest.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_MSP432_LaunchPad_IAR_CCS_Keil/Full_Demo/RunTimeStatsTimer.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_MSP432_LaunchPad_IAR_CCS_Keil/Full_Demo/RunTimeStatsTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_MSP432_LaunchPad_IAR_CCS_Keil/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_MSP432_LaunchPad_IAR_CCS_Keil/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_MSP432_LaunchPad_IAR_CCS_Keil/Full_Demo/serial.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_MSP432_LaunchPad_IAR_CCS_Keil/Full_Demo/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_MSP432_LaunchPad_IAR_CCS_Keil/SimplyBlinkyDemo/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_MSP432_LaunchPad_IAR_CCS_Keil/SimplyBlinkyDemo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_MSP432_LaunchPad_IAR_CCS_Keil/main.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_MSP432_LaunchPad_IAR_CCS_Keil/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_STM32F407ZG-SK/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M4F_STM32F407ZG-SK/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_STM32F407ZG-SK/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_STM32F407ZG-SK/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_STM32F407ZG-SK/RegTest.s
+++ b/FreeRTOS/Demo/CORTEX_M4F_STM32F407ZG-SK/RegTest.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_STM32F407ZG-SK/main.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_STM32F407ZG-SK/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4_ATSAM4L_Atmel_Studio/src/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_M4_ATSAM4L_Atmel_Studio/src/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4_ATSAM4L_Atmel_Studio/src/SAM4L_low_power_tick_management.c
+++ b/FreeRTOS/Demo/CORTEX_M4_ATSAM4L_Atmel_Studio/src/SAM4L_low_power_tick_management.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4_ATSAM4L_Atmel_Studio/src/config/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M4_ATSAM4L_Atmel_Studio/src/config/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4_ATSAM4L_Atmel_Studio/src/main.c
+++ b/FreeRTOS/Demo/CORTEX_M4_ATSAM4L_Atmel_Studio/src/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4_ATSAM4L_Atmel_Studio/src/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_M4_ATSAM4L_Atmel_Studio/src/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4_ATSAM4L_Atmel_Studio/src/main_low_power.c
+++ b/FreeRTOS/Demo/CORTEX_M4_ATSAM4L_Atmel_Studio/src/main_low_power.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4_ATSAM4S_Atmel_Studio/src/Common-Demo-Source/comtest.c
+++ b/FreeRTOS/Demo/CORTEX_M4_ATSAM4S_Atmel_Studio/src/Common-Demo-Source/comtest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4_ATSAM4S_Atmel_Studio/src/Common-Demo-Source/include/demo_serial.h
+++ b/FreeRTOS/Demo/CORTEX_M4_ATSAM4S_Atmel_Studio/src/Common-Demo-Source/include/demo_serial.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4_ATSAM4S_Atmel_Studio/src/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M4_ATSAM4S_Atmel_Studio/src/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4_ATSAM4S_Atmel_Studio/src/IntQueueTimer.c
+++ b/FreeRTOS/Demo/CORTEX_M4_ATSAM4S_Atmel_Studio/src/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4_ATSAM4S_Atmel_Studio/src/IntQueueTimer.h
+++ b/FreeRTOS/Demo/CORTEX_M4_ATSAM4S_Atmel_Studio/src/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4_ATSAM4S_Atmel_Studio/src/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_M4_ATSAM4S_Atmel_Studio/src/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4_ATSAM4S_Atmel_Studio/src/main.c
+++ b/FreeRTOS/Demo/CORTEX_M4_ATSAM4S_Atmel_Studio/src/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4_ATSAM4S_Atmel_Studio/src/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_M4_ATSAM4S_Atmel_Studio/src/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4_ATSAM4S_Atmel_Studio/src/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_M4_ATSAM4S_Atmel_Studio/src/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4_ATSAM4S_Atmel_Studio/src/serial.c
+++ b/FreeRTOS/Demo/CORTEX_M4_ATSAM4S_Atmel_Studio/src/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4_SimpleLink_CC3220SF_CCS/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M4_SimpleLink_CC3220SF_CCS/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4_SimpleLink_CC3220SF_CCS/Full_Demo/RegTest.asm
+++ b/FreeRTOS/Demo/CORTEX_M4_SimpleLink_CC3220SF_CCS/Full_Demo/RegTest.asm
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.4.1
+; * FreeRTOS V202011.00
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4_SimpleLink_CC3220SF_CCS/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_M4_SimpleLink_CC3220SF_CCS/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4_SimpleLink_CC3220SF_CCS/Simply_Blinky_Demo/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_M4_SimpleLink_CC3220SF_CCS/Simply_Blinky_Demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4_SimpleLink_CC3220SF_CCS/main.c
+++ b/FreeRTOS/Demo/CORTEX_M4_SimpleLink_CC3220SF_CCS/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_M4_AMP_STM32H745I_Discovery_IAR/CM4/include/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M7_M4_AMP_STM32H745I_Discovery_IAR/CM4/include/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_M4_AMP_STM32H745I_Discovery_IAR/CM4/main.c
+++ b/FreeRTOS/Demo/CORTEX_M7_M4_AMP_STM32H745I_Discovery_IAR/CM4/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_M4_AMP_STM32H745I_Discovery_IAR/CM7/include/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M7_M4_AMP_STM32H745I_Discovery_IAR/CM7/include/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_M4_AMP_STM32H745I_Discovery_IAR/CM7/main.c
+++ b/FreeRTOS/Demo/CORTEX_M7_M4_AMP_STM32H745I_Discovery_IAR/CM7/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_M4_AMP_STM32H745I_Discovery_IAR/MessageBufferLocations.h
+++ b/FreeRTOS/Demo/CORTEX_M7_M4_AMP_STM32H745I_Discovery_IAR/MessageBufferLocations.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_SAME70_Xplained_AtmelStudio/src/Blinky_Demo/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_M7_SAME70_Xplained_AtmelStudio/src/Blinky_Demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_SAME70_Xplained_AtmelStudio/src/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M7_SAME70_Xplained_AtmelStudio/src/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_SAME70_Xplained_AtmelStudio/src/Full_Demo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/CORTEX_M7_SAME70_Xplained_AtmelStudio/src/Full_Demo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_SAME70_Xplained_AtmelStudio/src/Full_Demo/IntQueueTimer.h
+++ b/FreeRTOS/Demo/CORTEX_M7_SAME70_Xplained_AtmelStudio/src/Full_Demo/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_SAME70_Xplained_AtmelStudio/src/Full_Demo/RegTest_GCC.c
+++ b/FreeRTOS/Demo/CORTEX_M7_SAME70_Xplained_AtmelStudio/src/Full_Demo/RegTest_GCC.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_SAME70_Xplained_AtmelStudio/src/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_M7_SAME70_Xplained_AtmelStudio/src/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_SAME70_Xplained_AtmelStudio/src/main.c
+++ b/FreeRTOS/Demo/CORTEX_M7_SAME70_Xplained_AtmelStudio/src/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_AtmelStudio/Blinky_Demo/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_AtmelStudio/Blinky_Demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_AtmelStudio/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_AtmelStudio/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_AtmelStudio/Full_Demo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_AtmelStudio/Full_Demo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_AtmelStudio/Full_Demo/IntQueueTimer.h
+++ b/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_AtmelStudio/Full_Demo/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_AtmelStudio/Full_Demo/RegTest_GCC.c
+++ b/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_AtmelStudio/Full_Demo/RegTest_GCC.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_AtmelStudio/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_AtmelStudio/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_AtmelStudio/main.c
+++ b/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_AtmelStudio/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_IAR_Keil/Blinky_Demo/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_IAR_Keil/Blinky_Demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_IAR_Keil/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_IAR_Keil/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_IAR_Keil/Full_Demo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_IAR_Keil/Full_Demo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_IAR_Keil/Full_Demo/IntQueueTimer.h
+++ b/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_IAR_Keil/Full_Demo/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_IAR_Keil/Full_Demo/RegTest.c
+++ b/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_IAR_Keil/Full_Demo/RegTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_IAR_Keil/Full_Demo/RegTest.s
+++ b/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_IAR_Keil/Full_Demo/RegTest.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_IAR_Keil/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_IAR_Keil/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_IAR_Keil/main.c
+++ b/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_IAR_Keil/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_STM32F7_STM32756G-EVAL_IAR_Keil/Blinky_Demo/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_M7_STM32F7_STM32756G-EVAL_IAR_Keil/Blinky_Demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_STM32F7_STM32756G-EVAL_IAR_Keil/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M7_STM32F7_STM32756G-EVAL_IAR_Keil/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_STM32F7_STM32756G-EVAL_IAR_Keil/Full_Demo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/CORTEX_M7_STM32F7_STM32756G-EVAL_IAR_Keil/Full_Demo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_STM32F7_STM32756G-EVAL_IAR_Keil/Full_Demo/IntQueueTimer.h
+++ b/FreeRTOS/Demo/CORTEX_M7_STM32F7_STM32756G-EVAL_IAR_Keil/Full_Demo/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_STM32F7_STM32756G-EVAL_IAR_Keil/Full_Demo/RegTest_IAR.s
+++ b/FreeRTOS/Demo/CORTEX_M7_STM32F7_STM32756G-EVAL_IAR_Keil/Full_Demo/RegTest_IAR.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_STM32F7_STM32756G-EVAL_IAR_Keil/Full_Demo/RegTest_Keil.c
+++ b/FreeRTOS/Demo/CORTEX_M7_STM32F7_STM32756G-EVAL_IAR_Keil/Full_Demo/RegTest_Keil.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_STM32F7_STM32756G-EVAL_IAR_Keil/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_M7_STM32F7_STM32756G-EVAL_IAR_Keil/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_STM32F7_STM32756G-EVAL_IAR_Keil/main.c
+++ b/FreeRTOS/Demo/CORTEX_M7_STM32F7_STM32756G-EVAL_IAR_Keil/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MB9A310_IAR_Keil/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_MB9A310_IAR_Keil/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MB9A310_IAR_Keil/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_MB9A310_IAR_Keil/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MB9A310_IAR_Keil/main-full.c
+++ b/FreeRTOS/Demo/CORTEX_MB9A310_IAR_Keil/main-full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MB9A310_IAR_Keil/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_MB9A310_IAR_Keil/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MB9A310_IAR_Keil/serial.c
+++ b/FreeRTOS/Demo/CORTEX_MB9A310_IAR_Keil/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MB9B500_IAR_Keil/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_MB9B500_IAR_Keil/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MB9B500_IAR_Keil/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_MB9B500_IAR_Keil/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MB9B500_IAR_Keil/main-full.c
+++ b/FreeRTOS/Demo/CORTEX_MB9B500_IAR_Keil/main-full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MB9B500_IAR_Keil/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_MB9B500_IAR_Keil/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MB9B500_IAR_Keil/serial.c
+++ b/FreeRTOS/Demo/CORTEX_MB9B500_IAR_Keil/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_CEC_MEC_17xx_51xx_Keil_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_MPU_CEC_MEC_17xx_51xx_Keil_GCC/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_CEC_MEC_17xx_51xx_Keil_GCC/GCC_Specific/RegTest.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_CEC_MEC_17xx_51xx_Keil_GCC/GCC_Specific/RegTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_CEC_MEC_17xx_51xx_Keil_GCC/Keil_Specific/RegTest.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_CEC_MEC_17xx_51xx_Keil_GCC/Keil_Specific/RegTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_CEC_MEC_17xx_51xx_Keil_GCC/main.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_CEC_MEC_17xx_51xx_Keil_GCC/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_LPC54018_MCUXpresso/Config/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_MPU_LPC54018_MCUXpresso/Config/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_LPC54018_MCUXpresso/Demo/main.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_LPC54018_MCUXpresso/Demo/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_LPC54018_MCUXpresso/Demo/mpu_demo.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_LPC54018_MCUXpresso/Demo/mpu_demo.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_LPC54018_MCUXpresso/Demo/mpu_demo.h
+++ b/FreeRTOS/Demo/CORTEX_MPU_LPC54018_MCUXpresso/Demo/mpu_demo.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_LPC54018_MCUXpresso/Projects/MCUXpresso/Startup/memfault_handler.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_LPC54018_MCUXpresso/Projects/MCUXpresso/Startup/memfault_handler.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_M23_Nuvoton_NuMaker_PFM_M2351_IAR_GCC/Projects/IAR/Config/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_MPU_M23_Nuvoton_NuMaker_PFM_M2351_IAR_GCC/Projects/IAR/Config/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_M23_Nuvoton_NuMaker_PFM_M2351_IAR_GCC/Projects/IAR/NonSecure/fault_handler.s
+++ b/FreeRTOS/Demo/CORTEX_MPU_M23_Nuvoton_NuMaker_PFM_M2351_IAR_GCC/Projects/IAR/NonSecure/fault_handler.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_M23_Nuvoton_NuMaker_PFM_M2351_IAR_GCC/Projects/IAR/NonSecure/main_ns.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_M23_Nuvoton_NuMaker_PFM_M2351_IAR_GCC/Projects/IAR/NonSecure/main_ns.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_M23_Nuvoton_NuMaker_PFM_M2351_IAR_GCC/Projects/IAR/Secure/main_s.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_M23_Nuvoton_NuMaker_PFM_M2351_IAR_GCC/Projects/IAR/Secure/main_s.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_M23_Nuvoton_NuMaker_PFM_M2351_IAR_GCC/Projects/Keil/Config/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_MPU_M23_Nuvoton_NuMaker_PFM_M2351_IAR_GCC/Projects/Keil/Config/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_M23_Nuvoton_NuMaker_PFM_M2351_IAR_GCC/Projects/Keil/NonSecure/main_ns.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_M23_Nuvoton_NuMaker_PFM_M2351_IAR_GCC/Projects/Keil/NonSecure/main_ns.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_M23_Nuvoton_NuMaker_PFM_M2351_IAR_GCC/Projects/Keil/Secure/main_s.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_M23_Nuvoton_NuMaker_PFM_M2351_IAR_GCC/Projects/Keil/Secure/main_s.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_M33F_NXP_LPC55S69_MCUXpresso/Projects/MCUXpresso/Config/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_MPU_M33F_NXP_LPC55S69_MCUXpresso/Projects/MCUXpresso/Config/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_M33F_NXP_LPC55S69_MCUXpresso/Projects/MCUXpresso/NonSecure/main_ns.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_M33F_NXP_LPC55S69_MCUXpresso/Projects/MCUXpresso/NonSecure/main_ns.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_M33F_NXP_LPC55S69_MCUXpresso/Projects/MCUXpresso/Secure/main_s.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_M33F_NXP_LPC55S69_MCUXpresso/Projects/MCUXpresso/Secure/main_s.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_M33F_Simulator_Keil_GCC/Config/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_MPU_M33F_Simulator_Keil_GCC/Config/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_M33F_Simulator_Keil_GCC/NonSecure/main_ns.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_M33F_Simulator_Keil_GCC/NonSecure/main_ns.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_M33F_Simulator_Keil_GCC/Secure/main_s.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_M33F_Simulator_Keil_GCC/Secure/main_s.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_M3_NUCLEO_L152RE_GCC/Config/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_MPU_M3_NUCLEO_L152RE_GCC/Config/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_M3_NUCLEO_L152RE_GCC/Demo/app_main.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_M3_NUCLEO_L152RE_GCC/Demo/app_main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_M3_NUCLEO_L152RE_GCC/Demo/app_main.h
+++ b/FreeRTOS/Demo/CORTEX_MPU_M3_NUCLEO_L152RE_GCC/Demo/app_main.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_M3_NUCLEO_L152RE_GCC/Demo/mpu_demo.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_M3_NUCLEO_L152RE_GCC/Demo/mpu_demo.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_M3_NUCLEO_L152RE_GCC/Demo/mpu_demo.h
+++ b/FreeRTOS/Demo/CORTEX_MPU_M3_NUCLEO_L152RE_GCC/Demo/mpu_demo.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_M3_NUCLEO_L152RE_GCC/Projects/GCC/Startup/memfault_handler.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_M3_NUCLEO_L152RE_GCC/Projects/GCC/Startup/memfault_handler.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_M7_NUCLEO_H743ZI2_GCC_IAR_Keil/Config/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_MPU_M7_NUCLEO_H743ZI2_GCC_IAR_Keil/Config/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_M7_NUCLEO_H743ZI2_GCC_IAR_Keil/Demo/app_main.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_M7_NUCLEO_H743ZI2_GCC_IAR_Keil/Demo/app_main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_M7_NUCLEO_H743ZI2_GCC_IAR_Keil/Demo/app_main.h
+++ b/FreeRTOS/Demo/CORTEX_MPU_M7_NUCLEO_H743ZI2_GCC_IAR_Keil/Demo/app_main.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_M7_NUCLEO_H743ZI2_GCC_IAR_Keil/Demo/mpu_demo.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_M7_NUCLEO_H743ZI2_GCC_IAR_Keil/Demo/mpu_demo.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_M7_NUCLEO_H743ZI2_GCC_IAR_Keil/Demo/mpu_demo.h
+++ b/FreeRTOS/Demo/CORTEX_MPU_M7_NUCLEO_H743ZI2_GCC_IAR_Keil/Demo/mpu_demo.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_M7_NUCLEO_H743ZI2_GCC_IAR_Keil/Projects/GCC/Startup/memfault_handler.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_M7_NUCLEO_H743ZI2_GCC_IAR_Keil/Projects/GCC/Startup/memfault_handler.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_M7_NUCLEO_H743ZI2_GCC_IAR_Keil/Projects/IAR/memfault_handler.s
+++ b/FreeRTOS/Demo/CORTEX_MPU_M7_NUCLEO_H743ZI2_GCC_IAR_Keil/Projects/IAR/memfault_handler.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_M7_NUCLEO_H743ZI2_GCC_IAR_Keil/Projects/Keil/memfault_handler.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_M7_NUCLEO_H743ZI2_GCC_IAR_Keil/Projects/Keil/memfault_handler.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_STM32L4_Discovery_GCC_IAR_Keil/Config/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_MPU_STM32L4_Discovery_GCC_IAR_Keil/Config/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_STM32L4_Discovery_GCC_IAR_Keil/Demo/app_main.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_STM32L4_Discovery_GCC_IAR_Keil/Demo/app_main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_STM32L4_Discovery_GCC_IAR_Keil/Demo/app_main.h
+++ b/FreeRTOS/Demo/CORTEX_MPU_STM32L4_Discovery_GCC_IAR_Keil/Demo/app_main.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_STM32L4_Discovery_GCC_IAR_Keil/Demo/mpu_demo.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_STM32L4_Discovery_GCC_IAR_Keil/Demo/mpu_demo.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_STM32L4_Discovery_GCC_IAR_Keil/Demo/mpu_demo.h
+++ b/FreeRTOS/Demo/CORTEX_MPU_STM32L4_Discovery_GCC_IAR_Keil/Demo/mpu_demo.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_STM32L4_Discovery_GCC_IAR_Keil/Projects/GCC/Startup/memfault_handler.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_STM32L4_Discovery_GCC_IAR_Keil/Projects/GCC/Startup/memfault_handler.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_STM32L4_Discovery_GCC_IAR_Keil/Projects/IAR/memfault_handler.s
+++ b/FreeRTOS/Demo/CORTEX_MPU_STM32L4_Discovery_GCC_IAR_Keil/Projects/IAR/memfault_handler.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_STM32L4_Discovery_GCC_IAR_Keil/Projects/Keil/memfault_handler.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_STM32L4_Discovery_GCC_IAR_Keil/Projects/Keil/memfault_handler.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_Simulator_Keil_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_MPU_Simulator_Keil_GCC/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_Simulator_Keil_GCC/GCC_Specific/RegTest.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_Simulator_Keil_GCC/GCC_Specific/RegTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_Simulator_Keil_GCC/Keil_Specific/RegTest.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_Simulator_Keil_GCC/Keil_Specific/RegTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_Simulator_Keil_GCC/main.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_Simulator_Keil_GCC/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_Static_Simulator_Keil_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_MPU_Static_Simulator_Keil_GCC/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_Static_Simulator_Keil_GCC/GCC_Specific/RegTest.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_Static_Simulator_Keil_GCC/GCC_Specific/RegTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_Static_Simulator_Keil_GCC/Keil_Specific/RegTest.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_Static_Simulator_Keil_GCC/Keil_Specific/RegTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_Static_Simulator_Keil_GCC/main.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_Static_Simulator_Keil_GCC/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R4F_RZ_T_GCC_IAR/System/IAR/Interrupt_Entry_Stubs.asm
+++ b/FreeRTOS/Demo/CORTEX_R4F_RZ_T_GCC_IAR/System/IAR/Interrupt_Entry_Stubs.asm
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R4F_RZ_T_GCC_IAR/src/Blinky_Demo/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_R4F_RZ_T_GCC_IAR/src/Blinky_Demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R4F_RZ_T_GCC_IAR/src/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_R4F_RZ_T_GCC_IAR/src/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R4F_RZ_T_GCC_IAR/src/FreeRTOS_tick_config.c
+++ b/FreeRTOS/Demo/CORTEX_R4F_RZ_T_GCC_IAR/src/FreeRTOS_tick_config.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R4F_RZ_T_GCC_IAR/src/Full_Demo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/CORTEX_R4F_RZ_T_GCC_IAR/src/Full_Demo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R4F_RZ_T_GCC_IAR/src/Full_Demo/IntQueueTimer.h
+++ b/FreeRTOS/Demo/CORTEX_R4F_RZ_T_GCC_IAR/src/Full_Demo/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R4F_RZ_T_GCC_IAR/src/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_R4F_RZ_T_GCC_IAR/src/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R4F_RZ_T_GCC_IAR/src/Full_Demo/reg_test_GCC.S
+++ b/FreeRTOS/Demo/CORTEX_R4F_RZ_T_GCC_IAR/src/Full_Demo/reg_test_GCC.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R4F_RZ_T_GCC_IAR/src/Full_Demo/reg_test_IAR.asm
+++ b/FreeRTOS/Demo/CORTEX_R4F_RZ_T_GCC_IAR/src/Full_Demo/reg_test_IAR.asm
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R4F_RZ_T_GCC_IAR/src/main.c
+++ b/FreeRTOS/Demo/CORTEX_R4F_RZ_T_GCC_IAR/src/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R4_RM48_TMS570_CCS5/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_R4_RM48_TMS570_CCS5/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R4_RM48_TMS570_CCS5/Library/het.c
+++ b/FreeRTOS/Demo/CORTEX_R4_RM48_TMS570_CCS5/Library/het.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R4_RM48_TMS570_CCS5/Library/het.h
+++ b/FreeRTOS/Demo/CORTEX_R4_RM48_TMS570_CCS5/Library/het.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R4_RM48_TMS570_CCS5/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_R4_RM48_TMS570_CCS5/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R4_RM48_TMS570_CCS5/flop_hercules.c
+++ b/FreeRTOS/Demo/CORTEX_R4_RM48_TMS570_CCS5/flop_hercules.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R4_RM48_TMS570_CCS5/flop_hercules.h
+++ b/FreeRTOS/Demo/CORTEX_R4_RM48_TMS570_CCS5/flop_hercules.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R4_RM48_TMS570_CCS5/main.c
+++ b/FreeRTOS/Demo/CORTEX_R4_RM48_TMS570_CCS5/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R4_RM48_TMS570_CCS5/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_R4_RM48_TMS570_CCS5/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R4_RM48_TMS570_CCS5/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_R4_RM48_TMS570_CCS5/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R4_RM48_TMS570_CCS5/reg_test.asm
+++ b/FreeRTOS/Demo/CORTEX_R4_RM48_TMS570_CCS5/reg_test.asm
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.4.1
+; * FreeRTOS V202011.00
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R4_RM48_TMS570_CCS5/serial.c
+++ b/FreeRTOS/Demo/CORTEX_R4_RM48_TMS570_CCS5/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R5_UltraScale_MPSoC/RTOSDemo_R5/src/Blinky_Demo/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_R5_UltraScale_MPSoC/RTOSDemo_R5/src/Blinky_Demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R5_UltraScale_MPSoC/RTOSDemo_R5/src/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_R5_UltraScale_MPSoC/RTOSDemo_R5/src/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R5_UltraScale_MPSoC/RTOSDemo_R5/src/FreeRTOS_tick_config.c
+++ b/FreeRTOS/Demo/CORTEX_R5_UltraScale_MPSoC/RTOSDemo_R5/src/FreeRTOS_tick_config.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R5_UltraScale_MPSoC/RTOSDemo_R5/src/Full_Demo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/CORTEX_R5_UltraScale_MPSoC/RTOSDemo_R5/src/Full_Demo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R5_UltraScale_MPSoC/RTOSDemo_R5/src/Full_Demo/IntQueueTimer.h
+++ b/FreeRTOS/Demo/CORTEX_R5_UltraScale_MPSoC/RTOSDemo_R5/src/Full_Demo/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R5_UltraScale_MPSoC/RTOSDemo_R5/src/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_R5_UltraScale_MPSoC/RTOSDemo_R5/src/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R5_UltraScale_MPSoC/RTOSDemo_R5/src/Full_Demo/reg_test.S
+++ b/FreeRTOS/Demo/CORTEX_R5_UltraScale_MPSoC/RTOSDemo_R5/src/Full_Demo/reg_test.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R5_UltraScale_MPSoC/RTOSDemo_R5/src/main.c
+++ b/FreeRTOS/Demo/CORTEX_R5_UltraScale_MPSoC/RTOSDemo_R5/src/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F100_Atollic/Simple_Demo_Source/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_STM32F100_Atollic/Simple_Demo_Source/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F100_Atollic/Simple_Demo_Source/main.c
+++ b/FreeRTOS/Demo/CORTEX_STM32F100_Atollic/Simple_Demo_Source/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F103_GCC_Rowley/Drivers/STM32_USART.c
+++ b/FreeRTOS/Demo/CORTEX_STM32F103_GCC_Rowley/Drivers/STM32_USART.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F103_GCC_Rowley/Drivers/STM32_USART.h
+++ b/FreeRTOS/Demo/CORTEX_STM32F103_GCC_Rowley/Drivers/STM32_USART.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F103_GCC_Rowley/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_STM32F103_GCC_Rowley/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F103_GCC_Rowley/ParTest/ParTest_MCBSTM32.c
+++ b/FreeRTOS/Demo/CORTEX_STM32F103_GCC_Rowley/ParTest/ParTest_MCBSTM32.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F103_GCC_Rowley/ParTest/ParTest_ST_Eval.c
+++ b/FreeRTOS/Demo/CORTEX_STM32F103_GCC_Rowley/ParTest/ParTest_ST_Eval.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F103_GCC_Rowley/main.c
+++ b/FreeRTOS/Demo/CORTEX_STM32F103_GCC_Rowley/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F103_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_STM32F103_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F103_IAR/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_STM32F103_IAR/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F103_IAR/main.c
+++ b/FreeRTOS/Demo/CORTEX_STM32F103_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F103_IAR/serial/serial.c
+++ b/FreeRTOS/Demo/CORTEX_STM32F103_IAR/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F103_IAR/timertest.c
+++ b/FreeRTOS/Demo/CORTEX_STM32F103_IAR/timertest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F103_Keil/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_STM32F103_Keil/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F103_Keil/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_STM32F103_Keil/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F103_Keil/main.c
+++ b/FreeRTOS/Demo/CORTEX_STM32F103_Keil/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F103_Keil/serial/serial.c
+++ b/FreeRTOS/Demo/CORTEX_STM32F103_Keil/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F103_Keil/timertest.c
+++ b/FreeRTOS/Demo/CORTEX_STM32F103_Keil/timertest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F103_Primer_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_STM32F103_Primer_GCC/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F103_Primer_GCC/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_STM32F103_Primer_GCC/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F103_Primer_GCC/bitmap.h
+++ b/FreeRTOS/Demo/CORTEX_STM32F103_Primer_GCC/bitmap.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F103_Primer_GCC/main.c
+++ b/FreeRTOS/Demo/CORTEX_STM32F103_Primer_GCC/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F103_Primer_GCC/timertest.c
+++ b/FreeRTOS/Demo/CORTEX_STM32F103_Primer_GCC/timertest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F107_GCC_Rowley/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_STM32F107_GCC_Rowley/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F107_GCC_Rowley/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_STM32F107_GCC_Rowley/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F107_GCC_Rowley/main.c
+++ b/FreeRTOS/Demo/CORTEX_STM32F107_GCC_Rowley/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F107_GCC_Rowley/scsc.tmp
+++ b/FreeRTOS/Demo/CORTEX_STM32F107_GCC_Rowley/scsc.tmp
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F107_GCC_Rowley/timertest.c
+++ b/FreeRTOS/Demo/CORTEX_STM32F107_GCC_Rowley/timertest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F107_GCC_Rowley/webserver/emac.c
+++ b/FreeRTOS/Demo/CORTEX_STM32F107_GCC_Rowley/webserver/emac.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F107_GCC_Rowley/webserver/emac.c.scsc
+++ b/FreeRTOS/Demo/CORTEX_STM32F107_GCC_Rowley/webserver/emac.c.scsc
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F107_GCC_Rowley/webserver/emac.h
+++ b/FreeRTOS/Demo/CORTEX_STM32F107_GCC_Rowley/webserver/emac.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F107_GCC_Rowley/webserver/emac.h.scsc
+++ b/FreeRTOS/Demo/CORTEX_STM32F107_GCC_Rowley/webserver/emac.h.scsc
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F107_GCC_Rowley/webserver/uIP_Task.c
+++ b/FreeRTOS/Demo/CORTEX_STM32F107_GCC_Rowley/webserver/uIP_Task.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32L152_Discovery_IAR/STM32L_low_power_tick_management.c
+++ b/FreeRTOS/Demo/CORTEX_STM32L152_Discovery_IAR/STM32L_low_power_tick_management.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32L152_Discovery_IAR/include/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_STM32L152_Discovery_IAR/include/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32L152_Discovery_IAR/main.c
+++ b/FreeRTOS/Demo/CORTEX_STM32L152_Discovery_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32L152_Discovery_IAR/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_STM32L152_Discovery_IAR/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32L152_Discovery_IAR/main_low_power.c
+++ b/FreeRTOS/Demo/CORTEX_STM32L152_Discovery_IAR/main_low_power.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32L152_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_STM32L152_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32L152_IAR/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_STM32L152_IAR/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32L152_IAR/main.c
+++ b/FreeRTOS/Demo/CORTEX_STM32L152_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32L152_IAR/serial.c
+++ b/FreeRTOS/Demo/CORTEX_STM32L152_IAR/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTUS_APS3_GCC/Demo/7seg.c
+++ b/FreeRTOS/Demo/CORTUS_APS3_GCC/Demo/7seg.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTUS_APS3_GCC/Demo/7seg.h
+++ b/FreeRTOS/Demo/CORTUS_APS3_GCC/Demo/7seg.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTUS_APS3_GCC/Demo/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTUS_APS3_GCC/Demo/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTUS_APS3_GCC/Demo/ParTest.c
+++ b/FreeRTOS/Demo/CORTUS_APS3_GCC/Demo/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTUS_APS3_GCC/Demo/RegTest.c
+++ b/FreeRTOS/Demo/CORTUS_APS3_GCC/Demo/RegTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTUS_APS3_GCC/Demo/RegTest.h
+++ b/FreeRTOS/Demo/CORTUS_APS3_GCC/Demo/RegTest.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTUS_APS3_GCC/Demo/demoGpio.h
+++ b/FreeRTOS/Demo/CORTUS_APS3_GCC/Demo/demoGpio.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTUS_APS3_GCC/Demo/main.c
+++ b/FreeRTOS/Demo/CORTUS_APS3_GCC/Demo/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTUS_APS3_GCC/Demo/serial.c
+++ b/FreeRTOS/Demo/CORTUS_APS3_GCC/Demo/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ColdFire_MCF51CN128_CodeWarrior/Sources/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/ColdFire_MCF51CN128_CodeWarrior/Sources/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ColdFire_MCF51CN128_CodeWarrior/Sources/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/ColdFire_MCF51CN128_CodeWarrior/Sources/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ColdFire_MCF51CN128_CodeWarrior/Sources/httpd/uIP_Task.c
+++ b/FreeRTOS/Demo/ColdFire_MCF51CN128_CodeWarrior/Sources/httpd/uIP_Task.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ColdFire_MCF51CN128_CodeWarrior/Sources/main.c
+++ b/FreeRTOS/Demo/ColdFire_MCF51CN128_CodeWarrior/Sources/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ColdFire_MCF52221_CodeWarrior/sources/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/ColdFire_MCF52221_CodeWarrior/sources/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ColdFire_MCF52221_CodeWarrior/sources/FreeRTOS_Tick_Setup.c
+++ b/FreeRTOS/Demo/ColdFire_MCF52221_CodeWarrior/sources/FreeRTOS_Tick_Setup.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ColdFire_MCF52221_CodeWarrior/sources/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/ColdFire_MCF52221_CodeWarrior/sources/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ColdFire_MCF52221_CodeWarrior/sources/main.c
+++ b/FreeRTOS/Demo/ColdFire_MCF52221_CodeWarrior/sources/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ColdFire_MCF52221_CodeWarrior/sources/serial/serial.c
+++ b/FreeRTOS/Demo/ColdFire_MCF52221_CodeWarrior/sources/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ColdFire_MCF52233_Eclipse/RTOSDemo/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/ColdFire_MCF52233_Eclipse/RTOSDemo/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ColdFire_MCF52233_Eclipse/RTOSDemo/FreeRTOS_Tick_Setup.c
+++ b/FreeRTOS/Demo/ColdFire_MCF52233_Eclipse/RTOSDemo/FreeRTOS_Tick_Setup.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ColdFire_MCF52233_Eclipse/RTOSDemo/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/ColdFire_MCF52233_Eclipse/RTOSDemo/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ColdFire_MCF52233_Eclipse/RTOSDemo/main.c
+++ b/FreeRTOS/Demo/ColdFire_MCF52233_Eclipse/RTOSDemo/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ColdFire_MCF52233_Eclipse/RTOSDemo/webserver/FEC.c
+++ b/FreeRTOS/Demo/ColdFire_MCF52233_Eclipse/RTOSDemo/webserver/FEC.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ColdFire_MCF52233_Eclipse/RTOSDemo/webserver/uIP_Task.c
+++ b/FreeRTOS/Demo/ColdFire_MCF52233_Eclipse/RTOSDemo/webserver/uIP_Task.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ColdFire_MCF52259_CodeWarrior/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/ColdFire_MCF52259_CodeWarrior/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ColdFire_MCF52259_CodeWarrior/FreeRTOS_Tick_Setup.c
+++ b/FreeRTOS/Demo/ColdFire_MCF52259_CodeWarrior/FreeRTOS_Tick_Setup.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ColdFire_MCF52259_CodeWarrior/HTTPDemo.c
+++ b/FreeRTOS/Demo/ColdFire_MCF52259_CodeWarrior/HTTPDemo.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ColdFire_MCF52259_CodeWarrior/HTTPDemo.h
+++ b/FreeRTOS/Demo/ColdFire_MCF52259_CodeWarrior/HTTPDemo.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ColdFire_MCF52259_CodeWarrior/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/ColdFire_MCF52259_CodeWarrior/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ColdFire_MCF52259_CodeWarrior/main.c
+++ b/FreeRTOS/Demo/ColdFire_MCF52259_CodeWarrior/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/ARMv8M/mpu_demo/mpu_demo.c
+++ b/FreeRTOS/Demo/Common/ARMv8M/mpu_demo/mpu_demo.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/ARMv8M/mpu_demo/mpu_demo.h
+++ b/FreeRTOS/Demo/Common/ARMv8M/mpu_demo/mpu_demo.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/ARMv8M/tz_demo/nsc_functions.c
+++ b/FreeRTOS/Demo/Common/ARMv8M/tz_demo/nsc_functions.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/ARMv8M/tz_demo/nsc_functions.h
+++ b/FreeRTOS/Demo/Common/ARMv8M/tz_demo/nsc_functions.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/ARMv8M/tz_demo/tz_demo.c
+++ b/FreeRTOS/Demo/Common/ARMv8M/tz_demo/tz_demo.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/ARMv8M/tz_demo/tz_demo.h
+++ b/FreeRTOS/Demo/Common/ARMv8M/tz_demo/tz_demo.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Full/BlockQ.c
+++ b/FreeRTOS/Demo/Common/Full/BlockQ.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Full/PollQ.c
+++ b/FreeRTOS/Demo/Common/Full/PollQ.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Full/comtest.c
+++ b/FreeRTOS/Demo/Common/Full/comtest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Full/death.c
+++ b/FreeRTOS/Demo/Common/Full/death.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Full/dynamic.c
+++ b/FreeRTOS/Demo/Common/Full/dynamic.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Full/events.c
+++ b/FreeRTOS/Demo/Common/Full/events.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Full/flash.c
+++ b/FreeRTOS/Demo/Common/Full/flash.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Full/flop.c
+++ b/FreeRTOS/Demo/Common/Full/flop.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Full/integer.c
+++ b/FreeRTOS/Demo/Common/Full/integer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Full/print.c
+++ b/FreeRTOS/Demo/Common/Full/print.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Full/semtest.c
+++ b/FreeRTOS/Demo/Common/Full/semtest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/AbortDelay.c
+++ b/FreeRTOS/Demo/Common/Minimal/AbortDelay.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/BlockQ.c
+++ b/FreeRTOS/Demo/Common/Minimal/BlockQ.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/EventGroupsDemo.c
+++ b/FreeRTOS/Demo/Common/Minimal/EventGroupsDemo.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/GenQTest.c
+++ b/FreeRTOS/Demo/Common/Minimal/GenQTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/IntQueue.c
+++ b/FreeRTOS/Demo/Common/Minimal/IntQueue.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/IntSemTest.c
+++ b/FreeRTOS/Demo/Common/Minimal/IntSemTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/MessageBufferAMP.c
+++ b/FreeRTOS/Demo/Common/Minimal/MessageBufferAMP.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/MessageBufferDemo.c
+++ b/FreeRTOS/Demo/Common/Minimal/MessageBufferDemo.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/PollQ.c
+++ b/FreeRTOS/Demo/Common/Minimal/PollQ.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/QPeek.c
+++ b/FreeRTOS/Demo/Common/Minimal/QPeek.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/QueueOverwrite.c
+++ b/FreeRTOS/Demo/Common/Minimal/QueueOverwrite.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/QueueSet.c
+++ b/FreeRTOS/Demo/Common/Minimal/QueueSet.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/QueueSetPolling.c
+++ b/FreeRTOS/Demo/Common/Minimal/QueueSetPolling.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/StaticAllocation.c
+++ b/FreeRTOS/Demo/Common/Minimal/StaticAllocation.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/StreamBufferDemo.c
+++ b/FreeRTOS/Demo/Common/Minimal/StreamBufferDemo.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/StreamBufferInterrupt.c
+++ b/FreeRTOS/Demo/Common/Minimal/StreamBufferInterrupt.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/TaskNotify.c
+++ b/FreeRTOS/Demo/Common/Minimal/TaskNotify.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/TaskNotifyArray.c
+++ b/FreeRTOS/Demo/Common/Minimal/TaskNotifyArray.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/TimerDemo.c
+++ b/FreeRTOS/Demo/Common/Minimal/TimerDemo.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/blocktim.c
+++ b/FreeRTOS/Demo/Common/Minimal/blocktim.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/comtest.c
+++ b/FreeRTOS/Demo/Common/Minimal/comtest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/comtest_strings.c
+++ b/FreeRTOS/Demo/Common/Minimal/comtest_strings.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/countsem.c
+++ b/FreeRTOS/Demo/Common/Minimal/countsem.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/crflash.c
+++ b/FreeRTOS/Demo/Common/Minimal/crflash.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/crhook.c
+++ b/FreeRTOS/Demo/Common/Minimal/crhook.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/death.c
+++ b/FreeRTOS/Demo/Common/Minimal/death.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/dynamic.c
+++ b/FreeRTOS/Demo/Common/Minimal/dynamic.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/flash.c
+++ b/FreeRTOS/Demo/Common/Minimal/flash.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/flash_timer.c
+++ b/FreeRTOS/Demo/Common/Minimal/flash_timer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/flop.c
+++ b/FreeRTOS/Demo/Common/Minimal/flop.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/integer.c
+++ b/FreeRTOS/Demo/Common/Minimal/integer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/recmutex.c
+++ b/FreeRTOS/Demo/Common/Minimal/recmutex.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/semtest.c
+++ b/FreeRTOS/Demo/Common/Minimal/semtest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/sp_flop.c
+++ b/FreeRTOS/Demo/Common/Minimal/sp_flop.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/ethernet/lwip-1.4.0/ports/MicroBlaze-Ethernet-Lite/ethernetif.c
+++ b/FreeRTOS/Demo/Common/ethernet/lwip-1.4.0/ports/MicroBlaze-Ethernet-Lite/ethernetif.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/ethernet/lwip-1.4.0/ports/win32/WinPCap/arch.c
+++ b/FreeRTOS/Demo/Common/ethernet/lwip-1.4.0/ports/win32/WinPCap/arch.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/ethernet/lwip-1.4.0/ports/win32/WinPCap/netif.h
+++ b/FreeRTOS/Demo/Common/ethernet/lwip-1.4.0/ports/win32/WinPCap/netif.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/ethernet/lwip-1.4.0/ports/win32/ethernetif.c
+++ b/FreeRTOS/Demo/Common/ethernet/lwip-1.4.0/ports/win32/ethernetif.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/AbortDelay.h
+++ b/FreeRTOS/Demo/Common/include/AbortDelay.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/BlockQ.h
+++ b/FreeRTOS/Demo/Common/include/BlockQ.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/EventGroupsDemo.h
+++ b/FreeRTOS/Demo/Common/include/EventGroupsDemo.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/GenQTest.h
+++ b/FreeRTOS/Demo/Common/include/GenQTest.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/IntQueue.h
+++ b/FreeRTOS/Demo/Common/include/IntQueue.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/IntSemTest.h
+++ b/FreeRTOS/Demo/Common/include/IntSemTest.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/MessageBufferAMP.h
+++ b/FreeRTOS/Demo/Common/include/MessageBufferAMP.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/MessageBufferDemo.h
+++ b/FreeRTOS/Demo/Common/include/MessageBufferDemo.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/PollQ.h
+++ b/FreeRTOS/Demo/Common/include/PollQ.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/QPeek.h
+++ b/FreeRTOS/Demo/Common/include/QPeek.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/QueueOverwrite.h
+++ b/FreeRTOS/Demo/Common/include/QueueOverwrite.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/QueueSet.h
+++ b/FreeRTOS/Demo/Common/include/QueueSet.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/QueueSetPolling.h
+++ b/FreeRTOS/Demo/Common/include/QueueSetPolling.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/StaticAllocation.h
+++ b/FreeRTOS/Demo/Common/include/StaticAllocation.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/StreamBufferDemo.h
+++ b/FreeRTOS/Demo/Common/include/StreamBufferDemo.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/StreamBufferInterrupt.h
+++ b/FreeRTOS/Demo/Common/include/StreamBufferInterrupt.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/TaskNotify.h
+++ b/FreeRTOS/Demo/Common/include/TaskNotify.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/TaskNotifyArray.h
+++ b/FreeRTOS/Demo/Common/include/TaskNotifyArray.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/TimerDemo.h
+++ b/FreeRTOS/Demo/Common/include/TimerDemo.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/blocktim.h
+++ b/FreeRTOS/Demo/Common/include/blocktim.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/comtest.h
+++ b/FreeRTOS/Demo/Common/include/comtest.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/comtest2.h
+++ b/FreeRTOS/Demo/Common/include/comtest2.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/comtest_strings.h
+++ b/FreeRTOS/Demo/Common/include/comtest_strings.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/countsem.h
+++ b/FreeRTOS/Demo/Common/include/countsem.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/crflash.h
+++ b/FreeRTOS/Demo/Common/include/crflash.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/crhook.h
+++ b/FreeRTOS/Demo/Common/include/crhook.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/death.h
+++ b/FreeRTOS/Demo/Common/include/death.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/dynamic.h
+++ b/FreeRTOS/Demo/Common/include/dynamic.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/fileIO.h
+++ b/FreeRTOS/Demo/Common/include/fileIO.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/flash.h
+++ b/FreeRTOS/Demo/Common/include/flash.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/flash_timer.h
+++ b/FreeRTOS/Demo/Common/include/flash_timer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/flop.h
+++ b/FreeRTOS/Demo/Common/include/flop.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/integer.h
+++ b/FreeRTOS/Demo/Common/include/integer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/mevents.h
+++ b/FreeRTOS/Demo/Common/include/mevents.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/partest.h
+++ b/FreeRTOS/Demo/Common/include/partest.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/print.h
+++ b/FreeRTOS/Demo/Common/include/print.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/recmutex.h
+++ b/FreeRTOS/Demo/Common/include/recmutex.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/semtest.h
+++ b/FreeRTOS/Demo/Common/include/semtest.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/serial.h
+++ b/FreeRTOS/Demo/Common/include/serial.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Cygnal/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/Cygnal/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Cygnal/Makefile
+++ b/FreeRTOS/Demo/Cygnal/Makefile
@@ -1,5 +1,5 @@
 #/*
-# * FreeRTOS Kernel V10.4.1
+# * FreeRTOS V202011.00
 # * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 # *
 # * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Cygnal/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/Cygnal/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Cygnal/main.c
+++ b/FreeRTOS/Demo/Cygnal/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Cygnal/serial/serial.c
+++ b/FreeRTOS/Demo/Cygnal/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Flshlite/FRConfig.h
+++ b/FreeRTOS/Demo/Flshlite/FRConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Flshlite/FileIO/fileIO.c
+++ b/FreeRTOS/Demo/Flshlite/FileIO/fileIO.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Flshlite/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/Flshlite/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Flshlite/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/Flshlite/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Flshlite/main.c
+++ b/FreeRTOS/Demo/Flshlite/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Flshlite/serial/serial.c
+++ b/FreeRTOS/Demo/Flshlite/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/H8S/RTOSDemo/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/H8S/RTOSDemo/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/H8S/RTOSDemo/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/H8S/RTOSDemo/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/H8S/RTOSDemo/main.c
+++ b/FreeRTOS/Demo/H8S/RTOSDemo/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/H8S/RTOSDemo/serial/serial.c
+++ b/FreeRTOS/Demo/H8S/RTOSDemo/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/HCS12_CodeWarrior_banked/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/HCS12_CodeWarrior_banked/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/HCS12_CodeWarrior_banked/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/HCS12_CodeWarrior_banked/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/HCS12_CodeWarrior_banked/main.c
+++ b/FreeRTOS/Demo/HCS12_CodeWarrior_banked/main.c
@@ -1,6 +1,6 @@
 
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/HCS12_CodeWarrior_banked/serial/serial.c
+++ b/FreeRTOS/Demo/HCS12_CodeWarrior_banked/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/HCS12_CodeWarrior_small/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/HCS12_CodeWarrior_small/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/HCS12_CodeWarrior_small/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/HCS12_CodeWarrior_small/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/HCS12_CodeWarrior_small/main.c
+++ b/FreeRTOS/Demo/HCS12_CodeWarrior_small/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/HCS12_CodeWarrior_small/serial/serial.c
+++ b/FreeRTOS/Demo/HCS12_CodeWarrior_small/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/HCS12_GCC_banked/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/HCS12_GCC_banked/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/HCS12_GCC_banked/ParTest.c
+++ b/FreeRTOS/Demo/HCS12_GCC_banked/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/HCS12_GCC_banked/main.c
+++ b/FreeRTOS/Demo/HCS12_GCC_banked/main.c
@@ -1,6 +1,6 @@
 
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/HCS12_GCC_banked/startup.c
+++ b/FreeRTOS/Demo/HCS12_GCC_banked/startup.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/IA32_flat_GCC_Galileo_Gen_2/Blinky_Demo/main_blinky.c
+++ b/FreeRTOS/Demo/IA32_flat_GCC_Galileo_Gen_2/Blinky_Demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/IA32_flat_GCC_Galileo_Gen_2/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/IA32_flat_GCC_Galileo_Gen_2/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/IA32_flat_GCC_Galileo_Gen_2/Full_Demo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/IA32_flat_GCC_Galileo_Gen_2/Full_Demo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/IA32_flat_GCC_Galileo_Gen_2/Full_Demo/IntQueueTimer.h
+++ b/FreeRTOS/Demo/IA32_flat_GCC_Galileo_Gen_2/Full_Demo/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/IA32_flat_GCC_Galileo_Gen_2/Full_Demo/RegTest.S
+++ b/FreeRTOS/Demo/IA32_flat_GCC_Galileo_Gen_2/Full_Demo/RegTest.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/IA32_flat_GCC_Galileo_Gen_2/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/IA32_flat_GCC_Galileo_Gen_2/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/IA32_flat_GCC_Galileo_Gen_2/Support_Files/freestanding_functions.c
+++ b/FreeRTOS/Demo/IA32_flat_GCC_Galileo_Gen_2/Support_Files/freestanding_functions.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/IA32_flat_GCC_Galileo_Gen_2/Support_Files/math.h
+++ b/FreeRTOS/Demo/IA32_flat_GCC_Galileo_Gen_2/Support_Files/math.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/IA32_flat_GCC_Galileo_Gen_2/Support_Files/startup.S
+++ b/FreeRTOS/Demo/IA32_flat_GCC_Galileo_Gen_2/Support_Files/startup.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/IA32_flat_GCC_Galileo_Gen_2/Support_Files/stdint.h
+++ b/FreeRTOS/Demo/IA32_flat_GCC_Galileo_Gen_2/Support_Files/stdint.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/IA32_flat_GCC_Galileo_Gen_2/main.c
+++ b/FreeRTOS/Demo/IA32_flat_GCC_Galileo_Gen_2/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MB91460_Softune/SRC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/MB91460_Softune/SRC/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MB91460_Softune/SRC/crflash_modified.c
+++ b/FreeRTOS/Demo/MB91460_Softune/SRC/crflash_modified.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MB91460_Softune/SRC/main.c
+++ b/FreeRTOS/Demo/MB91460_Softune/SRC/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MB91460_Softune/SRC/partest/partest.c
+++ b/FreeRTOS/Demo/MB91460_Softune/SRC/partest/partest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MB91460_Softune/SRC/serial/serial.c
+++ b/FreeRTOS/Demo/MB91460_Softune/SRC/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MB96340_Softune/FreeRTOS_96348hs_SK16FX100PMC/Src/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/MB96340_Softune/FreeRTOS_96348hs_SK16FX100PMC/Src/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MB96340_Softune/FreeRTOS_96348hs_SK16FX100PMC/Src/crflash_sk16fx100mpc.c
+++ b/FreeRTOS/Demo/MB96340_Softune/FreeRTOS_96348hs_SK16FX100PMC/Src/crflash_sk16fx100mpc.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MB96340_Softune/FreeRTOS_96348hs_SK16FX100PMC/Src/main.c
+++ b/FreeRTOS/Demo/MB96340_Softune/FreeRTOS_96348hs_SK16FX100PMC/Src/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MB96340_Softune/FreeRTOS_96348hs_SK16FX100PMC/Src/partest/partest.c
+++ b/FreeRTOS/Demo/MB96340_Softune/FreeRTOS_96348hs_SK16FX100PMC/Src/partest/partest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MB96340_Softune/FreeRTOS_96348hs_SK16FX100PMC/Src/serial/serial.c
+++ b/FreeRTOS/Demo/MB96340_Softune/FreeRTOS_96348hs_SK16FX100PMC/Src/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MB96350_Softune_Dice_Kit/DiceTask.c
+++ b/FreeRTOS/Demo/MB96350_Softune_Dice_Kit/DiceTask.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MB96350_Softune_Dice_Kit/DiceTask.h
+++ b/FreeRTOS/Demo/MB96350_Softune_Dice_Kit/DiceTask.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MB96350_Softune_Dice_Kit/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/MB96350_Softune_Dice_Kit/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MB96350_Softune_Dice_Kit/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/MB96350_Softune_Dice_Kit/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MB96350_Softune_Dice_Kit/SegmentToggleTasks.c
+++ b/FreeRTOS/Demo/MB96350_Softune_Dice_Kit/SegmentToggleTasks.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MB96350_Softune_Dice_Kit/main.c
+++ b/FreeRTOS/Demo/MB96350_Softune_Dice_Kit/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MSP430X_MSP430F5438_CCS/Demo_Source/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/MSP430X_MSP430F5438_CCS/Demo_Source/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MSP430X_MSP430F5438_CCS/Demo_Source/ParTest.c
+++ b/FreeRTOS/Demo/MSP430X_MSP430F5438_CCS/Demo_Source/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MSP430X_MSP430F5438_CCS/Demo_Source/RegTest.asm
+++ b/FreeRTOS/Demo/MSP430X_MSP430F5438_CCS/Demo_Source/RegTest.asm
@@ -1,6 +1,6 @@
 ;
 ;/*
-; * FreeRTOS Kernel V10.4.1
+; * FreeRTOS V202011.00
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MSP430X_MSP430F5438_CCS/Demo_Source/RunTimeStatsConfig.c
+++ b/FreeRTOS/Demo/MSP430X_MSP430F5438_CCS/Demo_Source/RunTimeStatsConfig.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MSP430X_MSP430F5438_CCS/Demo_Source/main.c
+++ b/FreeRTOS/Demo/MSP430X_MSP430F5438_CCS/Demo_Source/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MSP430X_MSP430F5438_CCS/Demo_Source/serial.c
+++ b/FreeRTOS/Demo/MSP430X_MSP430F5438_CCS/Demo_Source/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MSP430X_MSP430F5438_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/MSP430X_MSP430F5438_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MSP430X_MSP430F5438_IAR/ParTest.c
+++ b/FreeRTOS/Demo/MSP430X_MSP430F5438_IAR/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MSP430X_MSP430F5438_IAR/RegTest.s43
+++ b/FreeRTOS/Demo/MSP430X_MSP430F5438_IAR/RegTest.s43
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MSP430X_MSP430F5438_IAR/RunTimeStatsConfig.c
+++ b/FreeRTOS/Demo/MSP430X_MSP430F5438_IAR/RunTimeStatsConfig.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MSP430X_MSP430F5438_IAR/main.c
+++ b/FreeRTOS/Demo/MSP430X_MSP430F5438_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MSP430X_MSP430F5438_IAR/serial.c
+++ b/FreeRTOS/Demo/MSP430X_MSP430F5438_IAR/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MSP430X_MSP430FR5969_LaunchPad_IAR_CCS/Blinky_Demo/main_blinky.c
+++ b/FreeRTOS/Demo/MSP430X_MSP430FR5969_LaunchPad_IAR_CCS/Blinky_Demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MSP430X_MSP430FR5969_LaunchPad_IAR_CCS/CCS_Only/RegTest.asm
+++ b/FreeRTOS/Demo/MSP430X_MSP430FR5969_LaunchPad_IAR_CCS/CCS_Only/RegTest.asm
@@ -1,6 +1,6 @@
 ;
 ;/*
-; * FreeRTOS Kernel V10.4.1
+; * FreeRTOS V202011.00
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MSP430X_MSP430FR5969_LaunchPad_IAR_CCS/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/MSP430X_MSP430FR5969_LaunchPad_IAR_CCS/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MSP430X_MSP430FR5969_LaunchPad_IAR_CCS/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/MSP430X_MSP430FR5969_LaunchPad_IAR_CCS/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MSP430X_MSP430FR5969_LaunchPad_IAR_CCS/Full_Demo/serial.c
+++ b/FreeRTOS/Demo/MSP430X_MSP430FR5969_LaunchPad_IAR_CCS/Full_Demo/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MSP430X_MSP430FR5969_LaunchPad_IAR_CCS/IAR_Only/RegTest.s43
+++ b/FreeRTOS/Demo/MSP430X_MSP430FR5969_LaunchPad_IAR_CCS/IAR_Only/RegTest.s43
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MSP430X_MSP430FR5969_LaunchPad_IAR_CCS/LEDs.c
+++ b/FreeRTOS/Demo/MSP430X_MSP430FR5969_LaunchPad_IAR_CCS/LEDs.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MSP430X_MSP430FR5969_LaunchPad_IAR_CCS/main.c
+++ b/FreeRTOS/Demo/MSP430X_MSP430FR5969_LaunchPad_IAR_CCS/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MicroBlaze_Kintex7_EthernetLite/RTOSDemo/src/Blinky_Demo/main_blinky.c
+++ b/FreeRTOS/Demo/MicroBlaze_Kintex7_EthernetLite/RTOSDemo/src/Blinky_Demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MicroBlaze_Kintex7_EthernetLite/RTOSDemo/src/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/MicroBlaze_Kintex7_EthernetLite/RTOSDemo/src/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MicroBlaze_Kintex7_EthernetLite/RTOSDemo/src/Full_Demo/RegisterTests.S
+++ b/FreeRTOS/Demo/MicroBlaze_Kintex7_EthernetLite/RTOSDemo/src/Full_Demo/RegisterTests.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MicroBlaze_Kintex7_EthernetLite/RTOSDemo/src/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/MicroBlaze_Kintex7_EthernetLite/RTOSDemo/src/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MicroBlaze_Kintex7_EthernetLite/RTOSDemo/src/LEDs.c
+++ b/FreeRTOS/Demo/MicroBlaze_Kintex7_EthernetLite/RTOSDemo/src/LEDs.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MicroBlaze_Kintex7_EthernetLite/RTOSDemo/src/lwIP_Demo/lwIP_Apps/apps/BasicSocketCommandServer/BasicSocketCommandServer.c
+++ b/FreeRTOS/Demo/MicroBlaze_Kintex7_EthernetLite/RTOSDemo/src/lwIP_Demo/lwIP_Apps/apps/BasicSocketCommandServer/BasicSocketCommandServer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MicroBlaze_Kintex7_EthernetLite/RTOSDemo/src/lwIP_Demo/lwIP_Apps/lwIP_Apps.c
+++ b/FreeRTOS/Demo/MicroBlaze_Kintex7_EthernetLite/RTOSDemo/src/lwIP_Demo/lwIP_Apps/lwIP_Apps.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MicroBlaze_Kintex7_EthernetLite/RTOSDemo/src/lwIP_Demo/lwIP_Apps/lwIP_Apps.h
+++ b/FreeRTOS/Demo/MicroBlaze_Kintex7_EthernetLite/RTOSDemo/src/lwIP_Demo/lwIP_Apps/lwIP_Apps.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MicroBlaze_Kintex7_EthernetLite/RTOSDemo/src/lwIP_Demo/main_lwIP.c
+++ b/FreeRTOS/Demo/MicroBlaze_Kintex7_EthernetLite/RTOSDemo/src/lwIP_Demo/main_lwIP.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MicroBlaze_Kintex7_EthernetLite/RTOSDemo/src/main.c
+++ b/FreeRTOS/Demo/MicroBlaze_Kintex7_EthernetLite/RTOSDemo/src/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MicroBlaze_Kintex7_EthernetLite/RTOSDemo/src/serial.c
+++ b/FreeRTOS/Demo/MicroBlaze_Kintex7_EthernetLite/RTOSDemo/src/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/NEC_78K0R_IAR/ButtonISR.s26
+++ b/FreeRTOS/Demo/NEC_78K0R_IAR/ButtonISR.s26
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.4.1
+; * FreeRTOS V202011.00
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/NEC_78K0R_IAR/ButtonTask.c
+++ b/FreeRTOS/Demo/NEC_78K0R_IAR/ButtonTask.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/NEC_78K0R_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/NEC_78K0R_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/NEC_78K0R_IAR/RegTest.s26
+++ b/FreeRTOS/Demo/NEC_78K0R_IAR/RegTest.s26
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.4.1
+; * FreeRTOS V202011.00
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/NEC_78K0R_IAR/main.c
+++ b/FreeRTOS/Demo/NEC_78K0R_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/NEC_V850ES_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/NEC_V850ES_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/NEC_V850ES_IAR/LowLevelInit/LowLevelInit.c
+++ b/FreeRTOS/Demo/NEC_V850ES_IAR/LowLevelInit/LowLevelInit.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/NEC_V850ES_IAR/LowLevelInit/LowLevelInit_Fx3.c
+++ b/FreeRTOS/Demo/NEC_V850ES_IAR/LowLevelInit/LowLevelInit_Fx3.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/NEC_V850ES_IAR/LowLevelInit/LowLevelInit_Hx2.c
+++ b/FreeRTOS/Demo/NEC_V850ES_IAR/LowLevelInit/LowLevelInit_Hx2.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/NEC_V850ES_IAR/ParTest/ParTest_Fx3_App_Board.c
+++ b/FreeRTOS/Demo/NEC_V850ES_IAR/ParTest/ParTest_Fx3_App_Board.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/NEC_V850ES_IAR/ParTest/ParTest_Generic_Target_Board.c
+++ b/FreeRTOS/Demo/NEC_V850ES_IAR/ParTest/ParTest_Generic_Target_Board.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/NEC_V850ES_IAR/RegTest.s85
+++ b/FreeRTOS/Demo/NEC_V850ES_IAR/RegTest.s85
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.4.1
+; * FreeRTOS V202011.00
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/NEC_V850ES_IAR/main.c
+++ b/FreeRTOS/Demo/NEC_V850ES_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/NEC_V850ES_IAR/serial/serial.c
+++ b/FreeRTOS/Demo/NEC_V850ES_IAR/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/NiosII_CycloneIII_DBC3C40_GCC/RTOSDemo/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/NiosII_CycloneIII_DBC3C40_GCC/RTOSDemo/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/NiosII_CycloneIII_DBC3C40_GCC/RTOSDemo/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/NiosII_CycloneIII_DBC3C40_GCC/RTOSDemo/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/NiosII_CycloneIII_DBC3C40_GCC/RTOSDemo/main.c
+++ b/FreeRTOS/Demo/NiosII_CycloneIII_DBC3C40_GCC/RTOSDemo/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/NiosII_CycloneIII_DBC3C40_GCC/RTOSDemo/serial.c
+++ b/FreeRTOS/Demo/NiosII_CycloneIII_DBC3C40_GCC/RTOSDemo/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_MPLAB/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/PIC18_MPLAB/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_MPLAB/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/PIC18_MPLAB/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_MPLAB/main1.c
+++ b/FreeRTOS/Demo/PIC18_MPLAB/main1.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_MPLAB/main2.c
+++ b/FreeRTOS/Demo/PIC18_MPLAB/main2.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_MPLAB/main3.c
+++ b/FreeRTOS/Demo/PIC18_MPLAB/main3.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_MPLAB/serial/serial.c
+++ b/FreeRTOS/Demo/PIC18_MPLAB/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo1/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo1/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo1/WIZCmake.h
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo1/WIZCmake.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo1/fuses.c
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo1/fuses.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo1/interrupt.c
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo1/interrupt.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo1/main.c
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo1/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo2/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo2/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo2/WIZCmake.h
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo2/WIZCmake.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo2/fuses.c
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo2/fuses.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo2/interrupt.c
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo2/interrupt.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo2/main.c
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo2/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo3/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo3/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo3/WIZCmake.h
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo3/WIZCmake.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo3/fuses.c
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo3/fuses.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo3/interrupt.c
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo3/interrupt.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo3/main.c
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo3/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo4/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo4/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo4/WIZCmake.h
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo4/WIZCmake.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo4/fuses.c
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo4/fuses.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo4/interrupt.c
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo4/interrupt.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo4/main.c
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo4/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo5/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo5/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo5/WIZCmake.h
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo5/WIZCmake.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo5/fuses.c
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo5/fuses.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo5/interrupt.c
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo5/interrupt.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo5/main.c
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo5/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo6/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo6/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo6/WIZCmake.h
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo6/WIZCmake.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo6/fuses.c
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo6/fuses.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo6/interrupt.c
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo6/interrupt.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo6/main.c
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo6/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo7/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo7/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo7/WIZCmake.h
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo7/WIZCmake.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo7/fuses.c
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo7/fuses.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo7/interrupt.c
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo7/interrupt.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo7/main.c
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo7/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/PIC18_WizC/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/serial/isrSerialRx.c
+++ b/FreeRTOS/Demo/PIC18_WizC/serial/isrSerialRx.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/serial/isrSerialTx.c
+++ b/FreeRTOS/Demo/PIC18_WizC/serial/isrSerialTx.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/serial/serial.c
+++ b/FreeRTOS/Demo/PIC18_WizC/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC24_MPLAB/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/PIC24_MPLAB/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC24_MPLAB/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/PIC24_MPLAB/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC24_MPLAB/lcd.c
+++ b/FreeRTOS/Demo/PIC24_MPLAB/lcd.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC24_MPLAB/lcd.h
+++ b/FreeRTOS/Demo/PIC24_MPLAB/lcd.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC24_MPLAB/main.c
+++ b/FreeRTOS/Demo/PIC24_MPLAB/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC24_MPLAB/serial/serial.c
+++ b/FreeRTOS/Demo/PIC24_MPLAB/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC24_MPLAB/timertest.c
+++ b/FreeRTOS/Demo/PIC24_MPLAB/timertest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC24_MPLAB/timertest.h
+++ b/FreeRTOS/Demo/PIC24_MPLAB/timertest.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MEC14xx_MPLAB/src/Blinky_Demo/main_blinky.c
+++ b/FreeRTOS/Demo/PIC32MEC14xx_MPLAB/src/Blinky_Demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MEC14xx_MPLAB/src/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/PIC32MEC14xx_MPLAB/src/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MEC14xx_MPLAB/src/Full_Demo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/PIC32MEC14xx_MPLAB/src/Full_Demo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MEC14xx_MPLAB/src/Full_Demo/IntQueueTimer.h
+++ b/FreeRTOS/Demo/PIC32MEC14xx_MPLAB/src/Full_Demo/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MEC14xx_MPLAB/src/Full_Demo/IntQueueTimer_isr.S
+++ b/FreeRTOS/Demo/PIC32MEC14xx_MPLAB/src/Full_Demo/IntQueueTimer_isr.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MEC14xx_MPLAB/src/Full_Demo/RegisterTestTasks.S
+++ b/FreeRTOS/Demo/PIC32MEC14xx_MPLAB/src/Full_Demo/RegisterTestTasks.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MEC14xx_MPLAB/src/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/PIC32MEC14xx_MPLAB/src/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MEC14xx_MPLAB/src/Full_Demo/timertest.c
+++ b/FreeRTOS/Demo/PIC32MEC14xx_MPLAB/src/Full_Demo/timertest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MEC14xx_MPLAB/src/Full_Demo/timertest.h
+++ b/FreeRTOS/Demo/PIC32MEC14xx_MPLAB/src/Full_Demo/timertest.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MEC14xx_MPLAB/src/main.c
+++ b/FreeRTOS/Demo/PIC32MEC14xx_MPLAB/src/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MX_MPLAB/ConfigPerformance.c
+++ b/FreeRTOS/Demo/PIC32MX_MPLAB/ConfigPerformance.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MX_MPLAB/ConfigPerformance.h
+++ b/FreeRTOS/Demo/PIC32MX_MPLAB/ConfigPerformance.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MX_MPLAB/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/PIC32MX_MPLAB/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MX_MPLAB/IntQueueTimer.c
+++ b/FreeRTOS/Demo/PIC32MX_MPLAB/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MX_MPLAB/IntQueueTimer.h
+++ b/FreeRTOS/Demo/PIC32MX_MPLAB/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MX_MPLAB/IntQueueTimer_isr.S
+++ b/FreeRTOS/Demo/PIC32MX_MPLAB/IntQueueTimer_isr.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MX_MPLAB/ParTest/ParTest_Explorer16.c
+++ b/FreeRTOS/Demo/PIC32MX_MPLAB/ParTest/ParTest_Explorer16.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MX_MPLAB/ParTest/ParTest_USBII_Starter_Kit.c
+++ b/FreeRTOS/Demo/PIC32MX_MPLAB/ParTest/ParTest_USBII_Starter_Kit.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MX_MPLAB/RegisterTestTasks.S
+++ b/FreeRTOS/Demo/PIC32MX_MPLAB/RegisterTestTasks.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MX_MPLAB/lcd.c
+++ b/FreeRTOS/Demo/PIC32MX_MPLAB/lcd.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MX_MPLAB/lcd.h
+++ b/FreeRTOS/Demo/PIC32MX_MPLAB/lcd.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MX_MPLAB/main.c
+++ b/FreeRTOS/Demo/PIC32MX_MPLAB/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MX_MPLAB/main_blinky.c
+++ b/FreeRTOS/Demo/PIC32MX_MPLAB/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MX_MPLAB/main_full.c
+++ b/FreeRTOS/Demo/PIC32MX_MPLAB/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MX_MPLAB/serial/serial.c
+++ b/FreeRTOS/Demo/PIC32MX_MPLAB/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MX_MPLAB/timertest.c
+++ b/FreeRTOS/Demo/PIC32MX_MPLAB/timertest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MX_MPLAB/timertest.h
+++ b/FreeRTOS/Demo/PIC32MX_MPLAB/timertest.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MX_MPLAB/timertest_isr.S
+++ b/FreeRTOS/Demo/PIC32MX_MPLAB/timertest_isr.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MZ_MPLAB/ConfigPerformance.c
+++ b/FreeRTOS/Demo/PIC32MZ_MPLAB/ConfigPerformance.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MZ_MPLAB/ConfigPerformance.h
+++ b/FreeRTOS/Demo/PIC32MZ_MPLAB/ConfigPerformance.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MZ_MPLAB/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/PIC32MZ_MPLAB/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MZ_MPLAB/ISRTriggeredTask.c
+++ b/FreeRTOS/Demo/PIC32MZ_MPLAB/ISRTriggeredTask.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MZ_MPLAB/ISRTriggeredTask_isr.S
+++ b/FreeRTOS/Demo/PIC32MZ_MPLAB/ISRTriggeredTask_isr.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MZ_MPLAB/IntQueueTimer.c
+++ b/FreeRTOS/Demo/PIC32MZ_MPLAB/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MZ_MPLAB/IntQueueTimer.h
+++ b/FreeRTOS/Demo/PIC32MZ_MPLAB/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MZ_MPLAB/IntQueueTimer_isr.S
+++ b/FreeRTOS/Demo/PIC32MZ_MPLAB/IntQueueTimer_isr.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MZ_MPLAB/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/PIC32MZ_MPLAB/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MZ_MPLAB/RegisterTestTasks.S
+++ b/FreeRTOS/Demo/PIC32MZ_MPLAB/RegisterTestTasks.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MZ_MPLAB/flop_mz.c
+++ b/FreeRTOS/Demo/PIC32MZ_MPLAB/flop_mz.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MZ_MPLAB/flop_mz.h
+++ b/FreeRTOS/Demo/PIC32MZ_MPLAB/flop_mz.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MZ_MPLAB/main.c
+++ b/FreeRTOS/Demo/PIC32MZ_MPLAB/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MZ_MPLAB/main_blinky.c
+++ b/FreeRTOS/Demo/PIC32MZ_MPLAB/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MZ_MPLAB/main_full.c
+++ b/FreeRTOS/Demo/PIC32MZ_MPLAB/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MZ_MPLAB/timertest.c
+++ b/FreeRTOS/Demo/PIC32MZ_MPLAB/timertest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MZ_MPLAB/timertest.h
+++ b/FreeRTOS/Demo/PIC32MZ_MPLAB/timertest.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MZ_MPLAB/timertest_isr.S
+++ b/FreeRTOS/Demo/PIC32MZ_MPLAB/timertest_isr.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PPC440_DP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/PPC440_DP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PPC440_DP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/flop/flop-reg-test.c
+++ b/FreeRTOS/Demo/PPC440_DP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/flop/flop-reg-test.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PPC440_DP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/flop/flop-reg-test.h
+++ b/FreeRTOS/Demo/PPC440_DP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/flop/flop-reg-test.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PPC440_DP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/flop/flop.c
+++ b/FreeRTOS/Demo/PPC440_DP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/flop/flop.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PPC440_DP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/main.c
+++ b/FreeRTOS/Demo/PPC440_DP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PPC440_DP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/partest/partest.c
+++ b/FreeRTOS/Demo/PPC440_DP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/partest/partest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PPC440_DP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/serial/serial.c
+++ b/FreeRTOS/Demo/PPC440_DP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PPC440_SP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/PPC440_SP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PPC440_SP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/flop/flop-reg-test.c
+++ b/FreeRTOS/Demo/PPC440_SP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/flop/flop-reg-test.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PPC440_SP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/flop/flop-reg-test.h
+++ b/FreeRTOS/Demo/PPC440_SP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/flop/flop-reg-test.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PPC440_SP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/flop/flop.c
+++ b/FreeRTOS/Demo/PPC440_SP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/flop/flop.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PPC440_SP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/main.c
+++ b/FreeRTOS/Demo/PPC440_SP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PPC440_SP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/partest/partest.c
+++ b/FreeRTOS/Demo/PPC440_SP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/partest/partest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PPC440_SP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/serial/serial.c
+++ b/FreeRTOS/Demo/PPC440_SP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PPC440_Xilinx_Virtex5_GCC/RTOSDemo/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/PPC440_Xilinx_Virtex5_GCC/RTOSDemo/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PPC440_Xilinx_Virtex5_GCC/RTOSDemo/flop/flop-reg-test.c
+++ b/FreeRTOS/Demo/PPC440_Xilinx_Virtex5_GCC/RTOSDemo/flop/flop-reg-test.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PPC440_Xilinx_Virtex5_GCC/RTOSDemo/flop/flop-reg-test.h
+++ b/FreeRTOS/Demo/PPC440_Xilinx_Virtex5_GCC/RTOSDemo/flop/flop-reg-test.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PPC440_Xilinx_Virtex5_GCC/RTOSDemo/flop/flop.c
+++ b/FreeRTOS/Demo/PPC440_Xilinx_Virtex5_GCC/RTOSDemo/flop/flop.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PPC440_Xilinx_Virtex5_GCC/RTOSDemo/main.c
+++ b/FreeRTOS/Demo/PPC440_Xilinx_Virtex5_GCC/RTOSDemo/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PPC440_Xilinx_Virtex5_GCC/RTOSDemo/partest/partest.c
+++ b/FreeRTOS/Demo/PPC440_Xilinx_Virtex5_GCC/RTOSDemo/partest/partest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PPC440_Xilinx_Virtex5_GCC/RTOSDemo/serial/serial.c
+++ b/FreeRTOS/Demo/PPC440_Xilinx_Virtex5_GCC/RTOSDemo/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Posix_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/Posix_GCC/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Posix_GCC/FreeRTOSIPConfig.h
+++ b/FreeRTOS/Demo/Posix_GCC/FreeRTOSIPConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Posix_GCC/TCPEchoClient_SingleTasks.c
+++ b/FreeRTOS/Demo/Posix_GCC/TCPEchoClient_SingleTasks.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Posix_GCC/TCPEchoClient_SingleTasks.h
+++ b/FreeRTOS/Demo/Posix_GCC/TCPEchoClient_SingleTasks.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Posix_GCC/code_coverage_additions.c
+++ b/FreeRTOS/Demo/Posix_GCC/code_coverage_additions.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Posix_GCC/console.c
+++ b/FreeRTOS/Demo/Posix_GCC/console.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Cambridge Consultants Ltd.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Posix_GCC/console.h
+++ b/FreeRTOS/Demo/Posix_GCC/console.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Cambridge Consultants Ltd.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Posix_GCC/main.c
+++ b/FreeRTOS/Demo/Posix_GCC/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Posix_GCC/main_blinky.c
+++ b/FreeRTOS/Demo/Posix_GCC/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Posix_GCC/main_full.c
+++ b/FreeRTOS/Demo/Posix_GCC/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Posix_GCC/main_networking.c
+++ b/FreeRTOS/Demo/Posix_GCC/main_networking.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Posix_GCC/run-time-stats-utils.c
+++ b/FreeRTOS/Demo/Posix_GCC/run-time-stats-utils.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RISC-V-Qemu-sifive_e-Eclipse-GCC/blinky_demo/main_blinky.c
+++ b/FreeRTOS/Demo/RISC-V-Qemu-sifive_e-Eclipse-GCC/blinky_demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RISC-V-Qemu-sifive_e-Eclipse-GCC/full_demo/RegTest.S
+++ b/FreeRTOS/Demo/RISC-V-Qemu-sifive_e-Eclipse-GCC/full_demo/RegTest.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RISC-V-Qemu-sifive_e-Eclipse-GCC/full_demo/main_full.c
+++ b/FreeRTOS/Demo/RISC-V-Qemu-sifive_e-Eclipse-GCC/full_demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RISC-V-Qemu-sifive_e-Eclipse-GCC/main.c
+++ b/FreeRTOS/Demo/RISC-V-Qemu-sifive_e-Eclipse-GCC/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/FreeRTOSConfig.h
@@ -1,0 +1,104 @@
+/*
+ * FreeRTOS Kernel V10.4.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://www.github.com/FreeRTOS
+ *
+ * 1 tab == 4 spaces!
+ */
+
+#ifndef FREERTOS_CONFIG_H
+#define FREERTOS_CONFIG_H
+
+#include "riscv-virt.h"
+
+/*-----------------------------------------------------------
+ * Application specific definitions.
+ *
+ * These definitions should be adjusted for your particular hardware and
+ * application requirements.
+ *
+ * THESE PARAMETERS ARE DESCRIBED WITHIN THE 'CONFIGURATION' SECTION OF THE
+ * FreeRTOS API DOCUMENTATION AVAILABLE ON THE FreeRTOS.org WEB SITE.
+ *
+ * See http://www.freertos.org/a00110.html.
+ *----------------------------------------------------------*/
+
+/* See https://www.freertos.org/Using-FreeRTOS-on-RISC-V.html */
+#define configMTIME_BASE_ADDRESS		( CLINT_ADDR + CLINT_MTIME )
+#define configMTIMECMP_BASE_ADDRESS		( CLINT_ADDR + CLINT_MTIMECMP )
+
+#define configUSE_PREEMPTION			1
+#define configUSE_IDLE_HOOK				0
+#define configUSE_TICK_HOOK				1
+#define configCPU_CLOCK_HZ				( 1000000 )
+#define configTICK_RATE_HZ				( ( TickType_t ) 1000 )
+#define configMAX_PRIORITIES			( 7 )
+#define configMINIMAL_STACK_SIZE		( ( unsigned short ) 512 )
+#define configTOTAL_HEAP_SIZE			( ( size_t ) 64500 )
+#define configMAX_TASK_NAME_LEN			( 16 )
+#define configUSE_TRACE_FACILITY		0
+#define configUSE_16_BIT_TICKS			0
+#define configIDLE_SHOULD_YIELD			0
+#define configUSE_MUTEXES				1
+#define configQUEUE_REGISTRY_SIZE		8
+#define configCHECK_FOR_STACK_OVERFLOW	2
+#define configUSE_RECURSIVE_MUTEXES		1
+#define configUSE_MALLOC_FAILED_HOOK	1
+#define configUSE_APPLICATION_TASK_TAG	0
+#define configUSE_COUNTING_SEMAPHORES	1
+#define configGENERATE_RUN_TIME_STATS	0
+#define configUSE_PORT_OPTIMISED_TASK_SELECTION 1
+
+/* Co-routine definitions. */
+#define configUSE_CO_ROUTINES 			0
+#define configMAX_CO_ROUTINE_PRIORITIES ( 2 )
+
+/* Software timer definitions. */
+#define configUSE_TIMERS				1
+#define configTIMER_TASK_PRIORITY		( configMAX_PRIORITIES - 1 )
+#define configTIMER_QUEUE_LENGTH		6
+#define configTIMER_TASK_STACK_DEPTH	( 110 )
+
+/* RISC-V definitions. */
+#define configISR_STACK_SIZE_WORDS		2048
+
+/* Task priorities.  Allow these to be overridden. */
+#ifndef uartPRIMARY_PRIORITY
+	#define uartPRIMARY_PRIORITY		( configMAX_PRIORITIES - 3 )
+#endif
+
+/* Set the following definitions to 1 to include the API function, or zero
+to exclude the API function. */
+#define INCLUDE_vTaskPrioritySet			1
+#define INCLUDE_uxTaskPriorityGet			1
+#define INCLUDE_vTaskDelete					1
+#define INCLUDE_vTaskCleanUpResources		1
+#define INCLUDE_vTaskSuspend				1
+#define INCLUDE_vTaskDelayUntil				1
+#define INCLUDE_vTaskDelay					1
+#define INCLUDE_eTaskGetState				1
+#define INCLUDE_xTimerPendFunctionCall		1
+#define INCLUDE_xTaskAbortDelay				1
+#define INCLUDE_xTaskGetHandle				1
+#define INCLUDE_xSemaphoreGetMutexHolder	1
+
+#endif /* FREERTOS_CONFIG_H */

--- a/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/Makefile
+++ b/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/Makefile
@@ -1,0 +1,70 @@
+CROSS   = riscv64-unknown-elf-
+CC      = $(CROSS)gcc
+OBJCOPY = $(CROSS)objcopy
+ARCH    = $(CROSS)ar
+
+BUILD_DIR       = build
+RTOS_SOURCE_DIR = $(abspath ../../Source)
+DEMO_SOURCE_DIR = $(abspath ../Common/Minimal)
+
+CPPFLAGS = \
+	-D__riscv_float_abi_soft \
+	-DportasmHANDLE_INTERRUPT=handle_trap \
+	-I . -I ../Common/include \
+	-I $(RTOS_SOURCE_DIR)/include \
+	-I $(RTOS_SOURCE_DIR)/portable/GCC/RISC-V \
+	-I $(RTOS_SOURCE_DIR)/portable/GCC/RISC-V/chip_specific_extensions/RV32I_CLINT_no_extensions
+CFLAGS  = -march=rv32ima -mabi=ilp32 -mcmodel=medany \
+	-Wall \
+	-fmessage-length=0 \
+	-ffunction-sections \
+	-fdata-sections \
+	-fno-builtin-printf
+ASFLAGS = -march=rv32ima -mabi=ilp32 -mcmodel=medany
+LDFLAGS = -nostartfiles -Tfake_rom.lds \
+	-Xlinker --gc-sections \
+	-Xlinker --defsym=__stack_size=300
+
+ifeq ($(DEBUG), 1)
+    CFLAGS += -Og -ggdb3
+else
+    CFLAGS += -O2
+endif
+
+SRCS = main.c main_blinky.c riscv-virt.c ns16550.c \
+	$(DEMO_SOURCE_DIR)/EventGroupsDemo.c \
+	$(DEMO_SOURCE_DIR)/TaskNotify.c \
+	$(DEMO_SOURCE_DIR)/TimerDemo.c \
+	$(DEMO_SOURCE_DIR)/blocktim.c \
+	$(DEMO_SOURCE_DIR)/dynamic.c \
+	$(DEMO_SOURCE_DIR)/recmutex.c \
+	$(RTOS_SOURCE_DIR)/event_groups.c \
+	$(RTOS_SOURCE_DIR)/list.c \
+	$(RTOS_SOURCE_DIR)/queue.c \
+	$(RTOS_SOURCE_DIR)/stream_buffer.c \
+	$(RTOS_SOURCE_DIR)/tasks.c \
+	$(RTOS_SOURCE_DIR)/timers.c \
+	$(RTOS_SOURCE_DIR)/portable/MemMang/heap_4.c \
+	$(RTOS_SOURCE_DIR)/portable/GCC/RISC-V/port.c
+
+ASMS = start.S \
+	$(RTOS_SOURCE_DIR)/portable/GCC/RISC-V/portASM.S
+
+OBJS = $(SRCS:%.c=$(BUILD_DIR)/%.o) $(ASMS:%.S=$(BUILD_DIR)/%.o)
+DEPS = $(SRCS:%.c=$(BUILD_DIR)/%.d) $(ASMS:%.S=$(BUILD_DIR)/%.d)
+
+$(BUILD_DIR)/RTOSDemo.axf: $(OBJS) fake_rom.lds Makefile
+	$(CC) $(LDFLAGS) $(OBJS) -o $@
+
+$(BUILD_DIR)/%.o: %.c Makefile
+	@mkdir -p $(@D)
+	$(CC) $(CPPFLAGS) $(CFLAGS) -MMD -MP -c $< -o $@
+
+$(BUILD_DIR)/%.o: %.S Makefile
+	@mkdir -p $(@D)
+	$(CC) $(CPPFLAGS) $(ASFLAGS) -MMD -MP -c $< -o $@
+
+clean:
+	rm -rf $(BUILD_DIR)
+
+-include $(DEPS)

--- a/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/Readme.md
+++ b/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/Readme.md
@@ -1,0 +1,104 @@
+# Emulating generic RISC-V 32bit machine on QEMU
+
+## Requirements
+
+1. GNU RISC-V toolchains (tested on Crosstool-NG)
+1. qemu-riscv32-system (tested on Debian 10 package)
+1. Linux OS (tested on Debian 10)
+
+
+## How to build toolchain
+
+Clone the Crosstool-NG and build.
+
+```
+$ git clone https://github.com/crosstool-ng/crosstool-ng
+$ ./configure --enable-local
+$ make
+
+$ ./ct-ng menuconfig
+```
+
+Change the following configs:
+
+```
+CT_EXPERIMENTAL=y
+CT_ARCH_RISCV=y
+CT_ARCH_64=y
+CT_ARCH_ARCH=rv32ima
+CT_ARCH_ABI=ilp32
+CT_MULTILIB=y
+CT_DEBUG_GDB=y
+```
+
+Build the GNU toolchain for RISC-V.
+
+```
+$ ./ct-ng build
+```
+
+A toolchain is installed at ~/x-tools/riscv64-unknown-elf directory.
+
+
+## How to build
+
+Add path of toolchain that is described above section.
+
+```
+$ export PATH=~/x-tools/riscv64-unknown-elf:$PATH
+```
+
+For release build:
+
+```
+$ make
+```
+
+For debug build:
+
+```
+$ make DEBUG=1
+```
+
+If success to build, executable file RTOSDemo.axf in ./build directory.
+
+
+## How to run
+
+```
+$ qemu-system-riscv32 -nographic -machine virt -net none \
+  -chardev stdio,id=con,mux=on -serial chardev:con \
+  -mon chardev=con,mode=readline -bios none \
+  -smp 4 -kernel ./build/RTOSDemo.axf
+```
+
+
+## How to debug with gdb
+
+Append -s and -S options to the previous qemu command.
+
+- -s: enable to attach gdb to QEMU at port 1234
+- -S: start and halted CPU (wait for attach from gdb)
+
+This is just recommend to use 'debug build' for more efficient debugging.
+Run these commands after starting the QEMU with above options:
+
+```
+$ riscv64-unknown-elf-gdb build/RTOSDemo.axf
+
+(gdb) target remote localhost:1234
+(gdb) break main
+Breakpoint 1 at 0x80000110
+
+(gdb) c
+Continuing.
+
+Breakpoint 1, 0x80000110 in main ()
+```
+
+
+## Description
+
+This demo just prints Tx/Rx message of queue to serial port, use no
+other hardware and use only primary core (currently hart 0).
+Other cores are simply going to wfi state and execute nothing else.

--- a/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/fake_rom.lds
+++ b/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/fake_rom.lds
@@ -1,0 +1,117 @@
+OUTPUT_ARCH( "riscv" )
+ENTRY( _start )
+
+MEMORY
+{
+	/* Fake ROM area */
+	rom (rxa) : ORIGIN = 0x80000000, LENGTH = 512K
+	ram (wxa) : ORIGIN = 0x80080000, LENGTH = 512K
+}
+
+SECTIONS
+{
+	.init :
+	{
+		_text = .;
+		KEEP (*(SORT_NONE(.init)))
+	} >rom AT>rom
+	
+	.text :
+	{
+		*(.text.unlikely .text.unlikely.*)
+		*(.text.startup .text.startup.*)
+		*(.text .text.*)
+		*(.gnu.linkonce.t.*)
+	} >rom AT>rom
+	
+	.fini :
+	{
+		KEEP (*(SORT_NONE(.fini)))
+		_etext = .;
+	} >rom AT>rom
+
+	.rodata.align :
+	{
+		. = ALIGN(4);
+		_rodata = .;
+	} >rom AT>rom
+
+	.rodata.start :
+	{
+		_rodata_lma = LOADADDR(.rodata.start);
+	} >rom AT>rom
+
+	.rodata :
+	{
+		*(.rdata)
+		*(.rodata .rodata.*)
+		*(.gnu.linkonce.r.*)
+
+		. = ALIGN(4);
+		_erodata = .;
+	} >rom AT>rom
+
+	.data.align :
+	{
+		. = ALIGN(4);
+		_data = .;
+	} >ram AT>rom
+
+	.data.start :
+	{
+		_data_lma = LOADADDR(.data.start);
+	} >ram AT>rom
+
+	.data :
+	{
+		*(.data .data.*)
+		*(.gnu.linkonce.d.*)
+		. = ALIGN(8);
+		PROVIDE( __global_pointer$ = . + 0x800 );
+		*(.sdata .sdata.*)
+		*(.sdata2 .sdata2.*)
+		*(.gnu.linkonce.s.*)
+		. = ALIGN(8);
+		*(.srodata.cst16)
+		*(.srodata.cst8)
+		*(.srodata.cst4)
+		*(.srodata.cst2)
+		*(.srodata .srodata.*)
+
+		. = ALIGN(4);
+		_edata = .;
+	} >ram AT>rom
+
+	.bss.align :
+	{
+		. = ALIGN(4);
+		_bss = .;
+	} >ram AT>rom
+
+	.bss.start :
+	{
+		_bss_lma = LOADADDR(.bss.start);
+	} >ram AT>rom
+
+	.bss :
+	{
+		*(.sbss*)
+		*(.gnu.linkonce.sb.*)
+		*(.bss .bss.*)
+		*(.gnu.linkonce.b.*)
+		*(COMMON)
+
+		. = ALIGN(4);
+		_ebss = .;
+	} >ram AT>rom
+
+	. = ALIGN(8);
+	_end = .;
+
+	.stack :
+	{
+		. = ALIGN(16);
+		. += __stack_size;
+		_stack_top = .;
+	} >ram AT>ram
+}

--- a/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/main.c
+++ b/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/main.c
@@ -1,0 +1,117 @@
+/*
+ * FreeRTOS Kernel V10.4.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://www.github.com/FreeRTOS
+ *
+ * 1 tab == 4 spaces!
+ */
+
+/* FreeRTOS kernel includes. */
+#include <FreeRTOS.h>
+#include <task.h>
+
+/* Run a simple demo just prints 'Blink' */
+#define DEMO_BLINKY	1
+
+void vApplicationMallocFailedHook( void );
+void vApplicationIdleHook( void );
+void vApplicationStackOverflowHook( TaskHandle_t pxTask, char *pcTaskName );
+void vApplicationTickHook( void );
+
+int main_blinky( void );
+
+/*-----------------------------------------------------------*/
+
+int main( void )
+{
+	int ret;
+
+#if defined(DEMO_BLINKY)
+	ret = main_blinky();
+#else
+#error "Please add or select demo."
+#endif
+
+	return ret;
+}
+
+/*-----------------------------------------------------------*/
+
+void vApplicationMallocFailedHook( void )
+{
+	/* vApplicationMallocFailedHook() will only be called if
+	configUSE_MALLOC_FAILED_HOOK is set to 1 in FreeRTOSConfig.h.  It is a hook
+	function that will get called if a call to pvPortMalloc() fails.
+	pvPortMalloc() is called internally by the kernel whenever a task, queue,
+	timer or semaphore is created.  It is also called by various parts of the
+	demo application.  If heap_1.c or heap_2.c are used, then the size of the
+	heap available to pvPortMalloc() is defined by configTOTAL_HEAP_SIZE in
+	FreeRTOSConfig.h, and the xPortGetFreeHeapSize() API function can be used
+	to query the size of free heap space that remains (although it does not
+	provide information on how the remaining heap might be fragmented). */
+	taskDISABLE_INTERRUPTS();
+	for( ;; );
+}
+/*-----------------------------------------------------------*/
+
+void vApplicationIdleHook( void )
+{
+	/* vApplicationIdleHook() will only be called if configUSE_IDLE_HOOK is set
+	to 1 in FreeRTOSConfig.h.  It will be called on each iteration of the idle
+	task.  It is essential that code added to this hook function never attempts
+	to block in any way (for example, call xQueueReceive() with a block time
+	specified, or call vTaskDelay()).  If the application makes use of the
+	vTaskDelete() API function (as this demo application does) then it is also
+	important that vApplicationIdleHook() is permitted to return to its calling
+	function, because it is the responsibility of the idle task to clean up
+	memory allocated by the kernel to any task that has since been deleted. */
+}
+/*-----------------------------------------------------------*/
+
+void vApplicationStackOverflowHook( TaskHandle_t pxTask, char *pcTaskName )
+{
+	( void ) pcTaskName;
+	( void ) pxTask;
+
+	/* Run time stack overflow checking is performed if
+	configCHECK_FOR_STACK_OVERFLOW is defined to 1 or 2.  This hook
+	function is called if a stack overflow is detected. */
+	taskDISABLE_INTERRUPTS();
+	for( ;; );
+}
+/*-----------------------------------------------------------*/
+
+void vApplicationTickHook( void )
+{
+}
+/*-----------------------------------------------------------*/
+
+void vAssertCalled( void )
+{
+volatile uint32_t ulSetTo1ToExitFunction = 0;
+
+	taskDISABLE_INTERRUPTS();
+	while( ulSetTo1ToExitFunction != 1 )
+	{
+		__asm volatile( "NOP" );
+	}
+}

--- a/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/main_blinky.c
+++ b/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/main_blinky.c
@@ -1,0 +1,160 @@
+/*
+ * FreeRTOS Kernel V10.4.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://www.github.com/FreeRTOS
+ *
+ * 1 tab == 4 spaces!
+ */
+
+/* FreeRTOS kernel includes. */
+#include <FreeRTOS.h>
+#include <task.h>
+#include <queue.h>
+
+#include <stdio.h>
+
+#include "riscv-virt.h"
+#include "ns16550.h"
+
+/* Priorities used by the tasks. */
+#define mainQUEUE_RECEIVE_TASK_PRIORITY		( tskIDLE_PRIORITY + 2 )
+#define	mainQUEUE_SEND_TASK_PRIORITY		( tskIDLE_PRIORITY + 1 )
+
+/* The rate at which data is sent to the queue.  The 200ms value is converted
+to ticks using the pdMS_TO_TICKS() macro. */
+#define mainQUEUE_SEND_FREQUENCY_MS			pdMS_TO_TICKS( 1000 )
+
+/* The maximum number items the queue can hold.  The priority of the receiving
+task is above the priority of the sending task, so the receiving task will
+preempt the sending task and remove the queue items each time the sending task
+writes to the queue.  Therefore the queue will never have more than one item in
+it at any time, and even with a queue length of 1, the sending task will never
+find the queue full. */
+#define mainQUEUE_LENGTH					( 1 )
+
+/*-----------------------------------------------------------*/
+
+/* The queue used by both tasks. */
+static QueueHandle_t xQueue = NULL;
+
+/*-----------------------------------------------------------*/
+
+static void prvQueueSendTask( void *pvParameters )
+{
+TickType_t xNextWakeTime;
+const unsigned long ulValueToSend = 100UL;
+const char * const pcMessage1 = "Transfer1";
+const char * const pcMessage2 = "Transfer2";
+int f = 1;
+
+	/* Remove compiler warning about unused parameter. */
+	( void ) pvParameters;
+
+	/* Initialise xNextWakeTime - this only needs to be done once. */
+	xNextWakeTime = xTaskGetTickCount();
+
+	for( ;; )
+	{
+		char buf[40];
+
+		sprintf( buf, "%d: %s: %s", xGetCoreID(),
+				pcTaskGetName( xTaskGetCurrentTaskHandle() ),
+				( f ) ? pcMessage1 : pcMessage2 );
+		vSendString( buf );
+		f = !f;
+
+		/* Place this task in the blocked state until it is time to run again. */
+		vTaskDelayUntil( &xNextWakeTime, mainQUEUE_SEND_FREQUENCY_MS );
+
+		/* Send to the queue - causing the queue receive task to unblock and
+		toggle the LED.  0 is used as the block time so the sending operation
+		will not block - it shouldn't need to block as the queue should always
+		be empty at this point in the code. */
+		xQueueSend( xQueue, &ulValueToSend, 0U );
+	}
+}
+
+/*-----------------------------------------------------------*/
+
+static void prvQueueReceiveTask( void *pvParameters )
+{
+unsigned long ulReceivedValue;
+const unsigned long ulExpectedValue = 100UL;
+const char * const pcMessage1 = "Blink1";
+const char * const pcMessage2 = "Blink2";
+const char * const pcFailMessage = "Unexpected value received\r\n";
+int f = 1;
+
+	/* Remove compiler warning about unused parameter. */
+	( void ) pvParameters;
+
+	for( ;; )
+	{
+		char buf[40];
+
+		/* Wait until something arrives in the queue - this task will block
+		indefinitely provided INCLUDE_vTaskSuspend is set to 1 in
+		FreeRTOSConfig.h. */
+		xQueueReceive( xQueue, &ulReceivedValue, portMAX_DELAY );
+
+		/*  To get here something must have been received from the queue, but
+		is it the expected value?  If it is, toggle the LED. */
+		if( ulReceivedValue == ulExpectedValue )
+		{
+			sprintf( buf, "%d: %s: %s", xGetCoreID(),
+					pcTaskGetName( xTaskGetCurrentTaskHandle() ),
+					( f ) ? pcMessage1 : pcMessage2 );
+			vSendString( buf );
+			f = !f;
+
+			ulReceivedValue = 0U;
+		}
+		else
+		{
+			vSendString( pcFailMessage );
+		}
+	}
+}
+
+/*-----------------------------------------------------------*/
+
+int main_blinky( void )
+{
+	vSendString( "Hello FreeRTOS!" );
+
+	/* Create the queue. */
+	xQueue = xQueueCreate( mainQUEUE_LENGTH, sizeof( uint32_t ) );
+
+	if( xQueue != NULL )
+	{
+		/* Start the two tasks as described in the comments at the top of this
+		file. */
+		xTaskCreate( prvQueueReceiveTask, "Rx", configMINIMAL_STACK_SIZE * 2U, NULL,
+					mainQUEUE_RECEIVE_TASK_PRIORITY, NULL );
+		xTaskCreate( prvQueueSendTask, "Tx", configMINIMAL_STACK_SIZE * 2U, NULL,
+					mainQUEUE_SEND_TASK_PRIORITY, NULL );
+	}
+
+	vTaskStartScheduler();
+
+	return 0;
+}

--- a/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/ns16550.c
+++ b/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/ns16550.c
@@ -1,0 +1,75 @@
+/*
+ * FreeRTOS Kernel V10.4.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://www.github.com/FreeRTOS
+ *
+ * 1 tab == 4 spaces!
+ */
+
+#include <stdint.h>
+
+#include "ns16550.h"
+
+/* register definitions */
+#define REG_RBR		0x00 /* Receiver buffer reg. */
+#define REG_THR		0x00 /* Transmitter holding reg. */
+#define REG_IER		0x01 /* Interrupt enable reg. */
+#define REG_IIR		0x02 /* Interrupt ID reg. */
+#define REG_FCR		0x02 /* FIFO control reg. */
+#define REG_LCR		0x03 /* Line control reg. */
+#define REG_MCR		0x04 /* Modem control reg. */
+#define REG_LSR		0x05 /* Line status reg. */
+#define REG_MSR		0x06 /* Modem status reg. */
+#define REG_SCR		0x07 /* Scratch reg. */
+#define REG_BRDL	0x00 /* Divisor latch (LSB) */
+#define REG_BRDH	0x01 /* Divisor latch (MSB) */
+
+/* Line status */
+#define LSR_DR			0x01 /* Data ready */
+#define LSR_OE			0x02 /* Overrun error */
+#define LSR_PE			0x04 /* Parity error */
+#define LSR_FE			0x08 /* Framing error */
+#define LSR_BI			0x10 /* Break interrupt */
+#define LSR_THRE		0x20 /* Transmitter holding register empty */
+#define LSR_TEMT		0x40 /* Transmitter empty */
+#define LSR_EIRF		0x80 /* Error in RCVR FIFO */
+
+static uint8_t readb( uintptr_t addr )
+{
+	return *( (uint8_t *) addr );
+}
+
+static void writeb( uint8_t b, uintptr_t addr )
+{
+	*( (uint8_t *) addr ) = b;
+}
+
+void vOutNS16550( struct device *dev, unsigned char c )
+{
+	uintptr_t addr = dev->addr;
+
+	while ( (readb( addr + REG_LSR ) & LSR_THRE) == 0 ) {
+		/* busy wait */
+	}
+
+	writeb( c, addr + REG_THR );
+}

--- a/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/ns16550.h
+++ b/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/ns16550.h
@@ -1,0 +1,39 @@
+/*
+ * FreeRTOS Kernel V10.4.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://www.github.com/FreeRTOS
+ *
+ * 1 tab == 4 spaces!
+ */
+
+#ifndef NS16550_H_
+#define NS16550_H_
+
+#include <stdint.h>
+
+struct device {
+	uintptr_t addr;
+};
+
+void vOutNS16550( struct device *dev, unsigned char c );
+
+#endif /* NS16550_H_ */

--- a/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/riscv-reg.h
+++ b/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/riscv-reg.h
@@ -1,0 +1,43 @@
+/*
+ * FreeRTOS Kernel V10.4.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://www.github.com/FreeRTOS
+ *
+ * 1 tab == 4 spaces!
+ */
+
+#ifndef RISCV_REG_H_
+#define RISCV_REG_H_
+
+#if __riscv_xlen == 32
+#define REGSIZE		4
+#define REGSHIFT	2
+#define LOAD		lw
+#define STOR		sw
+#elif __riscv_xlen == 64
+#define REGSIZE		8
+#define REGSHIFT	3
+#define LOAD		ld
+#define STOR		sd
+#endif /* __riscv_xlen */
+
+#endif /* RISCV_REG_H_ */

--- a/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/riscv-virt.c
+++ b/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/riscv-virt.c
@@ -1,0 +1,65 @@
+/*
+ * FreeRTOS Kernel V10.4.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://www.github.com/FreeRTOS
+ *
+ * 1 tab == 4 spaces!
+ */
+
+#include <FreeRTOS.h>
+
+#include <string.h>
+
+#include "riscv-virt.h"
+#include "ns16550.h"
+
+int xGetCoreID( void )
+{
+int id;
+
+	__asm ("csrr %0, mhartid" : "=r" ( id ) );
+
+	return id;
+}
+
+void vSendString( const char *s )
+{
+struct device dev;
+size_t i;
+
+	dev.addr = NS16550_ADDR;
+
+	portENTER_CRITICAL();
+
+	for (i = 0; i < strlen(s); i++) {
+		vOutNS16550( &dev, s[i] );
+	}
+	vOutNS16550( &dev, '\n' );
+
+	portEXIT_CRITICAL();
+}
+
+void handle_trap(void)
+{
+	while (1)
+		;
+}

--- a/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/riscv-virt.h
+++ b/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/riscv-virt.h
@@ -1,0 +1,55 @@
+/*
+ * FreeRTOS Kernel V10.4.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://www.github.com/FreeRTOS
+ *
+ * 1 tab == 4 spaces!
+ */
+
+#ifndef RISCV_VIRT_H_
+#define RISCV_VIRT_H_
+
+#include "riscv-reg.h"
+
+#ifdef __ASSEMBLER__
+#define CONS(NUM, TYPE)NUM
+#else
+#define CONS(NUM, TYPE)NUM##TYPE
+#endif /* __ASSEMBLER__ */
+
+#define PRIM_HART			0
+
+#define CLINT_ADDR			CONS(0x02000000, UL)
+#define CLINT_MSIP			CONS(0x0000, UL)
+#define CLINT_MTIMECMP		CONS(0x4000, UL)
+#define CLINT_MTIME			CONS(0xbff8, UL)
+
+#define NS16550_ADDR		CONS(0x10000000, UL)
+
+#ifndef __ASSEMBLER__
+
+int xGetCoreID( void );
+void vSendString( const char * s );
+
+#endif /* __ASSEMBLER__ */
+
+#endif /* RISCV_VIRT_H_ */

--- a/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/start.S
+++ b/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/start.S
@@ -1,0 +1,85 @@
+/*
+ * FreeRTOS Kernel V10.4.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://www.github.com/FreeRTOS
+ *
+ * 1 tab == 4 spaces!
+ */
+
+#include "riscv-virt.h"
+
+	.section .init
+	.globl _start
+	.type _start,@function
+_start:
+	.cfi_startproc
+	.cfi_undefined ra
+.option push
+.option norelax
+	la  gp, __global_pointer$
+.option pop
+
+	// Continue primary hart
+	csrr a0, mhartid
+	li   a1, PRIM_HART
+	bne  a0, a1, secondary
+
+	// Primary hart
+	la sp, _stack_top
+
+	// Load data section
+	la a0, _data_lma
+	la a1, _data
+	la a2, _edata
+	bgeu a1, a2, 2f
+1:
+	LOAD t0, (a0)
+	STOR t0, (a1)
+	addi a0, a0, REGSIZE
+	addi a1, a1, REGSIZE
+	bltu a1, a2, 1b
+2:
+
+	// Clear bss section
+	la a0, _bss
+	la a1, _ebss
+	bgeu a0, a1, 2f
+1:
+	STOR zero, (a0)
+	addi a0, a0, REGSIZE
+	bltu a0, a1, 1b
+2:
+
+	// argc, argv, envp is 0
+	li  a0, 0
+	li  a1, 0
+	li  a2, 0
+	jal main
+1:
+	wfi
+	j 1b
+
+secondary:
+	// TODO: Multicore is not supported
+	wfi
+	j secondary
+	.cfi_endproc

--- a/FreeRTOS/Demo/RISC-V_RV32M1_Vega_GCC_Eclipse/projects/RTOSDemo_ri5cy/blinky_demo/main_blinky.c
+++ b/FreeRTOS/Demo/RISC-V_RV32M1_Vega_GCC_Eclipse/projects/RTOSDemo_ri5cy/blinky_demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RISC-V_RV32M1_Vega_GCC_Eclipse/projects/RTOSDemo_ri5cy/full_demo/RegTest.S
+++ b/FreeRTOS/Demo/RISC-V_RV32M1_Vega_GCC_Eclipse/projects/RTOSDemo_ri5cy/full_demo/RegTest.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RISC-V_RV32M1_Vega_GCC_Eclipse/projects/RTOSDemo_ri5cy/full_demo/main_full.c
+++ b/FreeRTOS/Demo/RISC-V_RV32M1_Vega_GCC_Eclipse/projects/RTOSDemo_ri5cy/full_demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RISC-V_RV32M1_Vega_GCC_Eclipse/projects/RTOSDemo_ri5cy/main.c
+++ b/FreeRTOS/Demo/RISC-V_RV32M1_Vega_GCC_Eclipse/projects/RTOSDemo_ri5cy/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RISC-V_RV32_SiFive_HiFive1-RevB_FreedomStudio/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RISC-V_RV32_SiFive_HiFive1-RevB_FreedomStudio/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RISC-V_RV32_SiFive_HiFive1-RevB_FreedomStudio/blinky_demo/main_blinky.c
+++ b/FreeRTOS/Demo/RISC-V_RV32_SiFive_HiFive1-RevB_FreedomStudio/blinky_demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RISC-V_RV32_SiFive_HiFive1-RevB_FreedomStudio/full_demo/RegTest.S
+++ b/FreeRTOS/Demo/RISC-V_RV32_SiFive_HiFive1-RevB_FreedomStudio/full_demo/RegTest.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RISC-V_RV32_SiFive_HiFive1-RevB_FreedomStudio/full_demo/main_full.c
+++ b/FreeRTOS/Demo/RISC-V_RV32_SiFive_HiFive1-RevB_FreedomStudio/full_demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RISC-V_RV32_SiFive_HiFive1-RevB_FreedomStudio/main.c
+++ b/FreeRTOS/Demo/RISC-V_RV32_SiFive_HiFive1-RevB_FreedomStudio/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RISC-V_RV32_SiFive_HiFive1-RevB_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RISC-V_RV32_SiFive_HiFive1-RevB_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RISC-V_RV32_SiFive_HiFive1-RevB_IAR/blinky_demo/main_blinky.c
+++ b/FreeRTOS/Demo/RISC-V_RV32_SiFive_HiFive1-RevB_IAR/blinky_demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RISC-V_RV32_SiFive_HiFive1-RevB_IAR/full_demo/RegTest.s
+++ b/FreeRTOS/Demo/RISC-V_RV32_SiFive_HiFive1-RevB_IAR/full_demo/RegTest.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RISC-V_RV32_SiFive_HiFive1-RevB_IAR/full_demo/main_full.c
+++ b/FreeRTOS/Demo/RISC-V_RV32_SiFive_HiFive1-RevB_IAR/full_demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RISC-V_RV32_SiFive_HiFive1-RevB_IAR/main.c
+++ b/FreeRTOS/Demo/RISC-V_RV32_SiFive_HiFive1-RevB_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RISC-V_Renode_Emulator_SoftConsole/blinky_demo/main_blinky.c
+++ b/FreeRTOS/Demo/RISC-V_Renode_Emulator_SoftConsole/blinky_demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RISC-V_Renode_Emulator_SoftConsole/full_demo/RegTest.S
+++ b/FreeRTOS/Demo/RISC-V_Renode_Emulator_SoftConsole/full_demo/RegTest.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RISC-V_Renode_Emulator_SoftConsole/full_demo/main_full.c
+++ b/FreeRTOS/Demo/RISC-V_Renode_Emulator_SoftConsole/full_demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RISC-V_Renode_Emulator_SoftConsole/main.c
+++ b/FreeRTOS/Demo/RISC-V_Renode_Emulator_SoftConsole/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RL78_RL78G13_Promo_Board_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RL78_RL78G13_Promo_Board_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RL78_RL78G13_Promo_Board_IAR/RegTest.s87
+++ b/FreeRTOS/Demo/RL78_RL78G13_Promo_Board_IAR/RegTest.s87
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.4.1
+; * FreeRTOS V202011.00
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RL78_RL78G13_Promo_Board_IAR/main.c
+++ b/FreeRTOS/Demo/RL78_RL78G13_Promo_Board_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RL78_multiple_IAR/ExampleISR.s87
+++ b/FreeRTOS/Demo/RL78_multiple_IAR/ExampleISR.s87
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.4.1
+; * FreeRTOS V202011.00
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RL78_multiple_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RL78_multiple_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RL78_multiple_IAR/RegTest.s87
+++ b/FreeRTOS/Demo/RL78_multiple_IAR/RegTest.s87
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.4.1
+; * FreeRTOS V202011.00
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RL78_multiple_IAR/demo_specific_io.h
+++ b/FreeRTOS/Demo/RL78_multiple_IAR/demo_specific_io.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RL78_multiple_IAR/main.c
+++ b/FreeRTOS/Demo/RL78_multiple_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RL78_multiple_IAR/main_blinky.c
+++ b/FreeRTOS/Demo/RL78_multiple_IAR/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RL78_multiple_IAR/main_full.c
+++ b/FreeRTOS/Demo/RL78_multiple_IAR/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100-RSK_GCC_e2studio/RTOSDemo/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RX100-RSK_GCC_e2studio/RTOSDemo/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100-RSK_GCC_e2studio/RTOSDemo/ParTest.c
+++ b/FreeRTOS/Demo/RX100-RSK_GCC_e2studio/RTOSDemo/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100-RSK_GCC_e2studio/RTOSDemo/main.c
+++ b/FreeRTOS/Demo/RX100-RSK_GCC_e2studio/RTOSDemo/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100-RSK_GCC_e2studio/RTOSDemo/main_full.c
+++ b/FreeRTOS/Demo/RX100-RSK_GCC_e2studio/RTOSDemo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100-RSK_GCC_e2studio/RTOSDemo/main_low_power.c
+++ b/FreeRTOS/Demo/RX100-RSK_GCC_e2studio/RTOSDemo/main_low_power.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100-RSK_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RX100-RSK_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100-RSK_IAR/ParTest.c
+++ b/FreeRTOS/Demo/RX100-RSK_IAR/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100-RSK_IAR/PriorityDefinitions.h
+++ b/FreeRTOS/Demo/RX100-RSK_IAR/PriorityDefinitions.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100-RSK_IAR/main.c
+++ b/FreeRTOS/Demo/RX100-RSK_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100-RSK_IAR/main_full.c
+++ b/FreeRTOS/Demo/RX100-RSK_IAR/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100-RSK_IAR/main_low_power.c
+++ b/FreeRTOS/Demo/RX100-RSK_IAR/main_low_power.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100-RSK_IAR/reg_test.s
+++ b/FreeRTOS/Demo/RX100-RSK_IAR/reg_test.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100-RSK_Renesas_e2studio/RTOSDemo/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RX100-RSK_Renesas_e2studio/RTOSDemo/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100-RSK_Renesas_e2studio/RTOSDemo/ParTest.c
+++ b/FreeRTOS/Demo/RX100-RSK_Renesas_e2studio/RTOSDemo/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100-RSK_Renesas_e2studio/RTOSDemo/main.c
+++ b/FreeRTOS/Demo/RX100-RSK_Renesas_e2studio/RTOSDemo/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100-RSK_Renesas_e2studio/RTOSDemo/main_full.c
+++ b/FreeRTOS/Demo/RX100-RSK_Renesas_e2studio/RTOSDemo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100-RSK_Renesas_e2studio/RTOSDemo/main_low_power.c
+++ b/FreeRTOS/Demo/RX100-RSK_Renesas_e2studio/RTOSDemo/main_low_power.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100_RX113-RSK_GCC_e2studio_IAR/src/Blinky_Demo/main_blinky.c
+++ b/FreeRTOS/Demo/RX100_RX113-RSK_GCC_e2studio_IAR/src/Blinky_Demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100_RX113-RSK_GCC_e2studio_IAR/src/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RX100_RX113-RSK_GCC_e2studio_IAR/src/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100_RX113-RSK_GCC_e2studio_IAR/src/Full_Demo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/RX100_RX113-RSK_GCC_e2studio_IAR/src/Full_Demo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100_RX113-RSK_GCC_e2studio_IAR/src/Full_Demo/IntQueueTimer.h
+++ b/FreeRTOS/Demo/RX100_RX113-RSK_GCC_e2studio_IAR/src/Full_Demo/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100_RX113-RSK_GCC_e2studio_IAR/src/Full_Demo/RegTest_GCC.S
+++ b/FreeRTOS/Demo/RX100_RX113-RSK_GCC_e2studio_IAR/src/Full_Demo/RegTest_GCC.S
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.4.1
+; * FreeRTOS V202011.00
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100_RX113-RSK_GCC_e2studio_IAR/src/Full_Demo/RegTest_IAR.s
+++ b/FreeRTOS/Demo/RX100_RX113-RSK_GCC_e2studio_IAR/src/Full_Demo/RegTest_IAR.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100_RX113-RSK_GCC_e2studio_IAR/src/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/RX100_RX113-RSK_GCC_e2studio_IAR/src/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100_RX113-RSK_GCC_e2studio_IAR/src/PriorityDefinitions.h
+++ b/FreeRTOS/Demo/RX100_RX113-RSK_GCC_e2studio_IAR/src/PriorityDefinitions.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100_RX113-RSK_GCC_e2studio_IAR/src/main.c
+++ b/FreeRTOS/Demo/RX100_RX113-RSK_GCC_e2studio_IAR/src/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100_RX113-RSK_Renesas_e2studio/src/Blinky_Demo/main_blinky.c
+++ b/FreeRTOS/Demo/RX100_RX113-RSK_Renesas_e2studio/src/Blinky_Demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100_RX113-RSK_Renesas_e2studio/src/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RX100_RX113-RSK_Renesas_e2studio/src/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100_RX113-RSK_Renesas_e2studio/src/Full_Demo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/RX100_RX113-RSK_Renesas_e2studio/src/Full_Demo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100_RX113-RSK_Renesas_e2studio/src/Full_Demo/IntQueueTimer.h
+++ b/FreeRTOS/Demo/RX100_RX113-RSK_Renesas_e2studio/src/Full_Demo/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100_RX113-RSK_Renesas_e2studio/src/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/RX100_RX113-RSK_Renesas_e2studio/src/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100_RX113-RSK_Renesas_e2studio/src/main.c
+++ b/FreeRTOS/Demo/RX100_RX113-RSK_Renesas_e2studio/src/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX200_RX210-RSK_Renesas/RTOSDemo/ButtonAndLCD.c
+++ b/FreeRTOS/Demo/RX200_RX210-RSK_Renesas/RTOSDemo/ButtonAndLCD.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX200_RX210-RSK_Renesas/RTOSDemo/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RX200_RX210-RSK_Renesas/RTOSDemo/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX200_RX210-RSK_Renesas/RTOSDemo/HighFrequencyTimerTest.c
+++ b/FreeRTOS/Demo/RX200_RX210-RSK_Renesas/RTOSDemo/HighFrequencyTimerTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX200_RX210-RSK_Renesas/RTOSDemo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/RX200_RX210-RSK_Renesas/RTOSDemo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX200_RX210-RSK_Renesas/RTOSDemo/ParTest.c
+++ b/FreeRTOS/Demo/RX200_RX210-RSK_Renesas/RTOSDemo/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX200_RX210-RSK_Renesas/RTOSDemo/include/ButtonAndLCD.h
+++ b/FreeRTOS/Demo/RX200_RX210-RSK_Renesas/RTOSDemo/include/ButtonAndLCD.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX200_RX210-RSK_Renesas/RTOSDemo/include/IntQueueTimer.h
+++ b/FreeRTOS/Demo/RX200_RX210-RSK_Renesas/RTOSDemo/include/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX200_RX210-RSK_Renesas/RTOSDemo/main-blinky.c
+++ b/FreeRTOS/Demo/RX200_RX210-RSK_Renesas/RTOSDemo/main-blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX200_RX210-RSK_Renesas/RTOSDemo/main-full.c
+++ b/FreeRTOS/Demo/RX200_RX210-RSK_Renesas/RTOSDemo/main-full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX200_RX231-RSK_GCC_e2studio_IAR/src/Blinky_Demo/main_blinky.c
+++ b/FreeRTOS/Demo/RX200_RX231-RSK_GCC_e2studio_IAR/src/Blinky_Demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX200_RX231-RSK_GCC_e2studio_IAR/src/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RX200_RX231-RSK_GCC_e2studio_IAR/src/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX200_RX231-RSK_GCC_e2studio_IAR/src/Full_Demo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/RX200_RX231-RSK_GCC_e2studio_IAR/src/Full_Demo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX200_RX231-RSK_GCC_e2studio_IAR/src/Full_Demo/IntQueueTimer.h
+++ b/FreeRTOS/Demo/RX200_RX231-RSK_GCC_e2studio_IAR/src/Full_Demo/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX200_RX231-RSK_GCC_e2studio_IAR/src/Full_Demo/RegTest_GCC.S
+++ b/FreeRTOS/Demo/RX200_RX231-RSK_GCC_e2studio_IAR/src/Full_Demo/RegTest_GCC.S
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.4.1
+; * FreeRTOS V202011.00
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX200_RX231-RSK_GCC_e2studio_IAR/src/Full_Demo/RegTest_IAR.s
+++ b/FreeRTOS/Demo/RX200_RX231-RSK_GCC_e2studio_IAR/src/Full_Demo/RegTest_IAR.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX200_RX231-RSK_GCC_e2studio_IAR/src/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/RX200_RX231-RSK_GCC_e2studio_IAR/src/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX200_RX231-RSK_GCC_e2studio_IAR/src/PriorityDefinitions.h
+++ b/FreeRTOS/Demo/RX200_RX231-RSK_GCC_e2studio_IAR/src/PriorityDefinitions.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX200_RX231-RSK_GCC_e2studio_IAR/src/main.c
+++ b/FreeRTOS/Demo/RX200_RX231-RSK_GCC_e2studio_IAR/src/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX200_RX231-RSK_Renesas_e2studio/src/Blinky_Demo/main_blinky.c
+++ b/FreeRTOS/Demo/RX200_RX231-RSK_Renesas_e2studio/src/Blinky_Demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX200_RX231-RSK_Renesas_e2studio/src/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RX200_RX231-RSK_Renesas_e2studio/src/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX200_RX231-RSK_Renesas_e2studio/src/Full_Demo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/RX200_RX231-RSK_Renesas_e2studio/src/Full_Demo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX200_RX231-RSK_Renesas_e2studio/src/Full_Demo/IntQueueTimer.h
+++ b/FreeRTOS/Demo/RX200_RX231-RSK_Renesas_e2studio/src/Full_Demo/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX200_RX231-RSK_Renesas_e2studio/src/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/RX200_RX231-RSK_Renesas_e2studio/src/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX200_RX231-RSK_Renesas_e2studio/src/main.c
+++ b/FreeRTOS/Demo/RX200_RX231-RSK_Renesas_e2studio/src/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_GNURX/RTOSDemo/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_GNURX/RTOSDemo/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_GNURX/RTOSDemo/HighFrequencyTimerTest.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_GNURX/RTOSDemo/HighFrequencyTimerTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_GNURX/RTOSDemo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_GNURX/RTOSDemo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_GNURX/RTOSDemo/ParTest.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_GNURX/RTOSDemo/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_GNURX/RTOSDemo/include/IntQueueTimer.h
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_GNURX/RTOSDemo/include/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_GNURX/RTOSDemo/main-blinky.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_GNURX/RTOSDemo/main-blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_GNURX/RTOSDemo/main-full.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_GNURX/RTOSDemo/main-full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_GNURX/RTOSDemo/uIP_Task.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_GNURX/RTOSDemo/uIP_Task.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_GNURX/RTOSDemo/webserver/EMAC.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_GNURX/RTOSDemo/webserver/EMAC.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_IAR/HighFrequencyTimerTest.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_IAR/HighFrequencyTimerTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_IAR/IntQueueTimer.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_IAR/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_IAR/ParTest.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_IAR/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_IAR/PriorityDefinitions.h
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_IAR/PriorityDefinitions.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_IAR/RegTest.s
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_IAR/RegTest.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_IAR/include/IntQueueTimer.h
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_IAR/include/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_IAR/main-blinky.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_IAR/main-blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_IAR/main-full.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_IAR/main-full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_IAR/uIP_Task.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_IAR/uIP_Task.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_IAR/webserver/EMAC.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_IAR/webserver/EMAC.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_Renesas/RTOSDemo/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_Renesas/RTOSDemo/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_Renesas/RTOSDemo/HighFrequencyTimerTest.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_Renesas/RTOSDemo/HighFrequencyTimerTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_Renesas/RTOSDemo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_Renesas/RTOSDemo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_Renesas/RTOSDemo/ParTest.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_Renesas/RTOSDemo/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_Renesas/RTOSDemo/include/IntQueueTimer.h
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_Renesas/RTOSDemo/include/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_Renesas/RTOSDemo/main-blinky.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_Renesas/RTOSDemo/main-blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_Renesas/RTOSDemo/main-full.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_Renesas/RTOSDemo/main-full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_Renesas/RTOSDemo/uIP_Task.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_Renesas/RTOSDemo/uIP_Task.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_Renesas/RTOSDemo/webserver/EMAC.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_Renesas/RTOSDemo/webserver/EMAC.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_GNURX/RTOSDemo/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_GNURX/RTOSDemo/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_GNURX/RTOSDemo/HighFrequencyTimerTest.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_GNURX/RTOSDemo/HighFrequencyTimerTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_GNURX/RTOSDemo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_GNURX/RTOSDemo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_GNURX/RTOSDemo/ParTest.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_GNURX/RTOSDemo/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_GNURX/RTOSDemo/include/IntQueueTimer.h
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_GNURX/RTOSDemo/include/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_GNURX/RTOSDemo/main-blinky.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_GNURX/RTOSDemo/main-blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_GNURX/RTOSDemo/main-full.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_GNURX/RTOSDemo/main-full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_GNURX/RTOSDemo/uIP_Task.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_GNURX/RTOSDemo/uIP_Task.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_GNURX/RTOSDemo/webserver/EMAC.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_GNURX/RTOSDemo/webserver/EMAC.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_IAR/HighFrequencyTimerTest.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_IAR/HighFrequencyTimerTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_IAR/IntQueueTimer.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_IAR/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_IAR/ParTest.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_IAR/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_IAR/PriorityDefinitions.h
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_IAR/PriorityDefinitions.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_IAR/RegTest.s
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_IAR/RegTest.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_IAR/include/IntQueueTimer.h
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_IAR/include/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_IAR/main-blinky.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_IAR/main-blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_IAR/main-full.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_IAR/main-full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_IAR/uIP_Task.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_IAR/uIP_Task.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_IAR/webserver/EMAC.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_IAR/webserver/EMAC.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_Renesas/RTOSDemo/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_Renesas/RTOSDemo/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_Renesas/RTOSDemo/HighFrequencyTimerTest.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_Renesas/RTOSDemo/HighFrequencyTimerTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_Renesas/RTOSDemo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_Renesas/RTOSDemo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_Renesas/RTOSDemo/ParTest.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_Renesas/RTOSDemo/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_Renesas/RTOSDemo/include/IntQueueTimer.h
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_Renesas/RTOSDemo/include/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_Renesas/RTOSDemo/main-blinky.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_Renesas/RTOSDemo/main-blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_Renesas/RTOSDemo/main-full.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_Renesas/RTOSDemo/main-full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_Renesas/RTOSDemo/uIP_Task.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_Renesas/RTOSDemo/uIP_Task.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_Renesas/RTOSDemo/webserver/EMAC.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_Renesas/RTOSDemo/webserver/EMAC.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX630-RSK_Renesas/RTOSDemo/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RX600_RX630-RSK_Renesas/RTOSDemo/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX630-RSK_Renesas/RTOSDemo/HighFrequencyTimerTest.c
+++ b/FreeRTOS/Demo/RX600_RX630-RSK_Renesas/RTOSDemo/HighFrequencyTimerTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX630-RSK_Renesas/RTOSDemo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/RX600_RX630-RSK_Renesas/RTOSDemo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX630-RSK_Renesas/RTOSDemo/ParTest.c
+++ b/FreeRTOS/Demo/RX600_RX630-RSK_Renesas/RTOSDemo/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX630-RSK_Renesas/RTOSDemo/include/IntQueueTimer.h
+++ b/FreeRTOS/Demo/RX600_RX630-RSK_Renesas/RTOSDemo/include/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX630-RSK_Renesas/RTOSDemo/main-blinky.c
+++ b/FreeRTOS/Demo/RX600_RX630-RSK_Renesas/RTOSDemo/main-blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX630-RSK_Renesas/RTOSDemo/main-full.c
+++ b/FreeRTOS/Demo/RX600_RX630-RSK_Renesas/RTOSDemo/main-full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX63N-RDK_Renesas/RTOSDemo/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RX600_RX63N-RDK_Renesas/RTOSDemo/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX63N-RDK_Renesas/RTOSDemo/HighFrequencyTimerTest.c
+++ b/FreeRTOS/Demo/RX600_RX63N-RDK_Renesas/RTOSDemo/HighFrequencyTimerTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX63N-RDK_Renesas/RTOSDemo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/RX600_RX63N-RDK_Renesas/RTOSDemo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX63N-RDK_Renesas/RTOSDemo/IntQueueTimer.h
+++ b/FreeRTOS/Demo/RX600_RX63N-RDK_Renesas/RTOSDemo/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX63N-RDK_Renesas/RTOSDemo/ParTest.c
+++ b/FreeRTOS/Demo/RX600_RX63N-RDK_Renesas/RTOSDemo/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX63N-RDK_Renesas/RTOSDemo/main-blinky.c
+++ b/FreeRTOS/Demo/RX600_RX63N-RDK_Renesas/RTOSDemo/main-blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX63N-RDK_Renesas/RTOSDemo/main-full.c
+++ b/FreeRTOS/Demo/RX600_RX63N-RDK_Renesas/RTOSDemo/main-full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX63N-RDK_Renesas/RTOSDemo/uIP_Task.c
+++ b/FreeRTOS/Demo/RX600_RX63N-RDK_Renesas/RTOSDemo/uIP_Task.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX63N-RDK_Renesas/RTOSDemo/webserver/EMAC.c
+++ b/FreeRTOS/Demo/RX600_RX63N-RDK_Renesas/RTOSDemo/webserver/EMAC.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX64M_RSK_GCC_e2studio/src/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RX600_RX64M_RSK_GCC_e2studio/src/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX64M_RSK_GCC_e2studio/src/IntQueueTimer.c
+++ b/FreeRTOS/Demo/RX600_RX64M_RSK_GCC_e2studio/src/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX64M_RSK_GCC_e2studio/src/IntQueueTimer.h
+++ b/FreeRTOS/Demo/RX600_RX64M_RSK_GCC_e2studio/src/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX64M_RSK_GCC_e2studio/src/ParTest.c
+++ b/FreeRTOS/Demo/RX600_RX64M_RSK_GCC_e2studio/src/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX64M_RSK_GCC_e2studio/src/RegTest.S
+++ b/FreeRTOS/Demo/RX600_RX64M_RSK_GCC_e2studio/src/RegTest.S
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.4.1
+; * FreeRTOS V202011.00
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX64M_RSK_GCC_e2studio/src/main.c
+++ b/FreeRTOS/Demo/RX600_RX64M_RSK_GCC_e2studio/src/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX64M_RSK_GCC_e2studio/src/main_blinky.c
+++ b/FreeRTOS/Demo/RX600_RX64M_RSK_GCC_e2studio/src/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX64M_RSK_GCC_e2studio/src/main_full.c
+++ b/FreeRTOS/Demo/RX600_RX64M_RSK_GCC_e2studio/src/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX64M_RSK_Renesas_e2studio/Source/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RX600_RX64M_RSK_Renesas_e2studio/Source/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX64M_RSK_Renesas_e2studio/Source/IntQueueTimer.c
+++ b/FreeRTOS/Demo/RX600_RX64M_RSK_Renesas_e2studio/Source/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX64M_RSK_Renesas_e2studio/Source/IntQueueTimer.h
+++ b/FreeRTOS/Demo/RX600_RX64M_RSK_Renesas_e2studio/Source/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX64M_RSK_Renesas_e2studio/Source/ParTest.c
+++ b/FreeRTOS/Demo/RX600_RX64M_RSK_Renesas_e2studio/Source/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX64M_RSK_Renesas_e2studio/Source/RegTest.src
+++ b/FreeRTOS/Demo/RX600_RX64M_RSK_Renesas_e2studio/Source/RegTest.src
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.4.1
+; * FreeRTOS V202011.00
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX64M_RSK_Renesas_e2studio/Source/main.c
+++ b/FreeRTOS/Demo/RX600_RX64M_RSK_Renesas_e2studio/Source/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX64M_RSK_Renesas_e2studio/Source/main_blinky.c
+++ b/FreeRTOS/Demo/RX600_RX64M_RSK_Renesas_e2studio/Source/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX64M_RSK_Renesas_e2studio/Source/main_full.c
+++ b/FreeRTOS/Demo/RX600_RX64M_RSK_Renesas_e2studio/Source/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX700_RX71M_RSK_GCC_e2studio_IAR/src/Blinky_Demo/main_blinky.c
+++ b/FreeRTOS/Demo/RX700_RX71M_RSK_GCC_e2studio_IAR/src/Blinky_Demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX700_RX71M_RSK_GCC_e2studio_IAR/src/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RX700_RX71M_RSK_GCC_e2studio_IAR/src/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX700_RX71M_RSK_GCC_e2studio_IAR/src/Full_Demo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/RX700_RX71M_RSK_GCC_e2studio_IAR/src/Full_Demo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX700_RX71M_RSK_GCC_e2studio_IAR/src/Full_Demo/IntQueueTimer.h
+++ b/FreeRTOS/Demo/RX700_RX71M_RSK_GCC_e2studio_IAR/src/Full_Demo/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX700_RX71M_RSK_GCC_e2studio_IAR/src/Full_Demo/RegTest_GCC.S
+++ b/FreeRTOS/Demo/RX700_RX71M_RSK_GCC_e2studio_IAR/src/Full_Demo/RegTest_GCC.S
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.4.1
+; * FreeRTOS V202011.00
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX700_RX71M_RSK_GCC_e2studio_IAR/src/Full_Demo/RegTest_IAR.s
+++ b/FreeRTOS/Demo/RX700_RX71M_RSK_GCC_e2studio_IAR/src/Full_Demo/RegTest_IAR.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX700_RX71M_RSK_GCC_e2studio_IAR/src/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/RX700_RX71M_RSK_GCC_e2studio_IAR/src/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX700_RX71M_RSK_GCC_e2studio_IAR/src/PriorityDefinitions.h
+++ b/FreeRTOS/Demo/RX700_RX71M_RSK_GCC_e2studio_IAR/src/PriorityDefinitions.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX700_RX71M_RSK_GCC_e2studio_IAR/src/main.c
+++ b/FreeRTOS/Demo/RX700_RX71M_RSK_GCC_e2studio_IAR/src/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX700_RX71M_RSK_Renesas_e2studio/src/Blinky_Demo/main_blinky.c
+++ b/FreeRTOS/Demo/RX700_RX71M_RSK_Renesas_e2studio/src/Blinky_Demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX700_RX71M_RSK_Renesas_e2studio/src/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RX700_RX71M_RSK_Renesas_e2studio/src/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX700_RX71M_RSK_Renesas_e2studio/src/Full_Demo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/RX700_RX71M_RSK_Renesas_e2studio/src/Full_Demo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX700_RX71M_RSK_Renesas_e2studio/src/Full_Demo/IntQueueTimer.h
+++ b/FreeRTOS/Demo/RX700_RX71M_RSK_Renesas_e2studio/src/Full_Demo/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX700_RX71M_RSK_Renesas_e2studio/src/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/RX700_RX71M_RSK_Renesas_e2studio/src/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX700_RX71M_RSK_Renesas_e2studio/src/main.c
+++ b/FreeRTOS/Demo/RX700_RX71M_RSK_Renesas_e2studio/src/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/SuperH_SH7216_Renesas/RTOSDemo/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/SuperH_SH7216_Renesas/RTOSDemo/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/SuperH_SH7216_Renesas/RTOSDemo/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/SuperH_SH7216_Renesas/RTOSDemo/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/SuperH_SH7216_Renesas/RTOSDemo/flop.c
+++ b/FreeRTOS/Demo/SuperH_SH7216_Renesas/RTOSDemo/flop.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/SuperH_SH7216_Renesas/RTOSDemo/main.c
+++ b/FreeRTOS/Demo/SuperH_SH7216_Renesas/RTOSDemo/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/SuperH_SH7216_Renesas/RTOSDemo/regtest.src
+++ b/FreeRTOS/Demo/SuperH_SH7216_Renesas/RTOSDemo/regtest.src
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.4.1
+; * FreeRTOS V202011.00
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/SuperH_SH7216_Renesas/RTOSDemo/uIP_Task.c
+++ b/FreeRTOS/Demo/SuperH_SH7216_Renesas/RTOSDemo/uIP_Task.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/SuperH_SH7216_Renesas/RTOSDemo/webserver/EMAC.c
+++ b/FreeRTOS/Demo/SuperH_SH7216_Renesas/RTOSDemo/webserver/EMAC.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/SuperH_SH7216_Renesas/RTOSDemo/webserver/EMAC_ISR.src
+++ b/FreeRTOS/Demo/SuperH_SH7216_Renesas/RTOSDemo/webserver/EMAC_ISR.src
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.4.1
+; * FreeRTOS V202011.00
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/T-HEAD_CB2201_CDK/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/T-HEAD_CB2201_CDK/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Tensilica_Simulator_Xplorer_XCC/IntQueueTimer.c
+++ b/FreeRTOS/Demo/Tensilica_Simulator_Xplorer_XCC/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Tensilica_Simulator_Xplorer_XCC/IntQueueTimer.h
+++ b/FreeRTOS/Demo/Tensilica_Simulator_Xplorer_XCC/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Tensilica_Simulator_Xplorer_XCC/main.c
+++ b/FreeRTOS/Demo/Tensilica_Simulator_Xplorer_XCC/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Tensilica_Simulator_Xplorer_XCC/main_blinky.c
+++ b/FreeRTOS/Demo/Tensilica_Simulator_Xplorer_XCC/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Tensilica_Simulator_Xplorer_XCC/main_full.c
+++ b/FreeRTOS/Demo/Tensilica_Simulator_Xplorer_XCC/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Tensilica_Simulator_Xplorer_XCC/regtest_xtensa.S
+++ b/FreeRTOS/Demo/Tensilica_Simulator_Xplorer_XCC/regtest_xtensa.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/TriCore_TC1782_TriBoard_GCC/RTOSDemo/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/TriCore_TC1782_TriBoard_GCC/RTOSDemo/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/TriCore_TC1782_TriBoard_GCC/RTOSDemo/InterruptNestTest.c
+++ b/FreeRTOS/Demo/TriCore_TC1782_TriBoard_GCC/RTOSDemo/InterruptNestTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/TriCore_TC1782_TriBoard_GCC/RTOSDemo/InterruptNestTest.h
+++ b/FreeRTOS/Demo/TriCore_TC1782_TriBoard_GCC/RTOSDemo/InterruptNestTest.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/TriCore_TC1782_TriBoard_GCC/RTOSDemo/ParTest.c
+++ b/FreeRTOS/Demo/TriCore_TC1782_TriBoard_GCC/RTOSDemo/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/TriCore_TC1782_TriBoard_GCC/RTOSDemo/main.c
+++ b/FreeRTOS/Demo/TriCore_TC1782_TriBoard_GCC/RTOSDemo/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/TriCore_TC1782_TriBoard_GCC/RTOSDemo/serial.c
+++ b/FreeRTOS/Demo/TriCore_TC1782_TriBoard_GCC/RTOSDemo/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WIN32-MSVC-Static-Allocation-Only/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/WIN32-MSVC-Static-Allocation-Only/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WIN32-MSVC-Static-Allocation-Only/main.c
+++ b/FreeRTOS/Demo/WIN32-MSVC-Static-Allocation-Only/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WIN32-MSVC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/WIN32-MSVC/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WIN32-MSVC/Run-time-stats-utils.c
+++ b/FreeRTOS/Demo/WIN32-MSVC/Run-time-stats-utils.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WIN32-MSVC/main.c
+++ b/FreeRTOS/Demo/WIN32-MSVC/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WIN32-MSVC/main_blinky.c
+++ b/FreeRTOS/Demo/WIN32-MSVC/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WIN32-MSVC/main_full.c
+++ b/FreeRTOS/Demo/WIN32-MSVC/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WIN32-MingW/DemosModifiedForLowTickRate/recmutex.c
+++ b/FreeRTOS/Demo/WIN32-MingW/DemosModifiedForLowTickRate/recmutex.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WIN32-MingW/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/WIN32-MingW/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WIN32-MingW/Run-time-stats-utils.c
+++ b/FreeRTOS/Demo/WIN32-MingW/Run-time-stats-utils.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WIN32-MingW/code_coverage_additions.c
+++ b/FreeRTOS/Demo/WIN32-MingW/code_coverage_additions.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WIN32-MingW/main.c
+++ b/FreeRTOS/Demo/WIN32-MingW/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WIN32-MingW/main_blinky.c
+++ b/FreeRTOS/Demo/WIN32-MingW/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WIN32-MingW/main_full.c
+++ b/FreeRTOS/Demo/WIN32-MingW/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WizNET_DEMO_GCC_ARM7/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/WizNET_DEMO_GCC_ARM7/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WizNET_DEMO_GCC_ARM7/HTTP_Serv.c
+++ b/FreeRTOS/Demo/WizNET_DEMO_GCC_ARM7/HTTP_Serv.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WizNET_DEMO_GCC_ARM7/HTTP_Serv.h
+++ b/FreeRTOS/Demo/WizNET_DEMO_GCC_ARM7/HTTP_Serv.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WizNET_DEMO_GCC_ARM7/Makefile
+++ b/FreeRTOS/Demo/WizNET_DEMO_GCC_ARM7/Makefile
@@ -1,5 +1,5 @@
 #/*
-# * FreeRTOS Kernel V10.4.1
+# * FreeRTOS V202011.00
 # * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 # *
 # * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WizNET_DEMO_GCC_ARM7/TCP.c
+++ b/FreeRTOS/Demo/WizNET_DEMO_GCC_ARM7/TCP.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WizNET_DEMO_GCC_ARM7/TCP.h
+++ b/FreeRTOS/Demo/WizNET_DEMO_GCC_ARM7/TCP.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WizNET_DEMO_GCC_ARM7/TCPISR.c
+++ b/FreeRTOS/Demo/WizNET_DEMO_GCC_ARM7/TCPISR.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WizNET_DEMO_GCC_ARM7/html_pages.h
+++ b/FreeRTOS/Demo/WizNET_DEMO_GCC_ARM7/html_pages.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WizNET_DEMO_GCC_ARM7/i2c.c
+++ b/FreeRTOS/Demo/WizNET_DEMO_GCC_ARM7/i2c.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WizNET_DEMO_GCC_ARM7/i2c.h
+++ b/FreeRTOS/Demo/WizNET_DEMO_GCC_ARM7/i2c.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WizNET_DEMO_GCC_ARM7/i2cISR.c
+++ b/FreeRTOS/Demo/WizNET_DEMO_GCC_ARM7/i2cISR.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WizNET_DEMO_GCC_ARM7/main.c
+++ b/FreeRTOS/Demo/WizNET_DEMO_GCC_ARM7/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WizNET_DEMO_TERN_186/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/WizNET_DEMO_TERN_186/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WizNET_DEMO_TERN_186/HTTPTask.c
+++ b/FreeRTOS/Demo/WizNET_DEMO_TERN_186/HTTPTask.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WizNET_DEMO_TERN_186/HTTPTask.h
+++ b/FreeRTOS/Demo/WizNET_DEMO_TERN_186/HTTPTask.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WizNET_DEMO_TERN_186/main.c
+++ b/FreeRTOS/Demo/WizNET_DEMO_TERN_186/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WizNET_DEMO_TERN_186/serial/serial.c
+++ b/FreeRTOS/Demo/WizNET_DEMO_TERN_186/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/dsPIC_MPLAB/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/dsPIC_MPLAB/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/dsPIC_MPLAB/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/dsPIC_MPLAB/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/dsPIC_MPLAB/lcd.c
+++ b/FreeRTOS/Demo/dsPIC_MPLAB/lcd.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/dsPIC_MPLAB/lcd.h
+++ b/FreeRTOS/Demo/dsPIC_MPLAB/lcd.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/dsPIC_MPLAB/main.c
+++ b/FreeRTOS/Demo/dsPIC_MPLAB/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/dsPIC_MPLAB/serial/serial.c
+++ b/FreeRTOS/Demo/dsPIC_MPLAB/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/dsPIC_MPLAB/timertest.c
+++ b/FreeRTOS/Demo/dsPIC_MPLAB/timertest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/dsPIC_MPLAB/timertest.h
+++ b/FreeRTOS/Demo/dsPIC_MPLAB/timertest.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/BasicWEB.c
+++ b/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/BasicWEB.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/BasicWEB.h
+++ b/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/BasicWEB.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/EMAC/SAM7_EMAC.c
+++ b/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/EMAC/SAM7_EMAC.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/EMAC/SAM7_EMAC.h
+++ b/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/EMAC/SAM7_EMAC.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/EMAC/SAM7_EMAC_ISR.c
+++ b/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/EMAC/SAM7_EMAC_ISR.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/USB/USB-CDC.c
+++ b/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/USB/USB-CDC.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/USB/USB-CDC.h
+++ b/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/USB/USB-CDC.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/USB/USBIsr.c
+++ b/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/USB/USBIsr.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/USB/descriptors.h
+++ b/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/USB/descriptors.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/USB/usb.h
+++ b/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/USB/usb.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/main.c
+++ b/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/makefile
+++ b/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/makefile
@@ -1,5 +1,5 @@
 #/*
-# * FreeRTOS Kernel V10.4.1
+# * FreeRTOS V202011.00
 # * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 # *
 # * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/msp430_CrossWorks/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/msp430_CrossWorks/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/msp430_CrossWorks/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/msp430_CrossWorks/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/msp430_CrossWorks/main.c
+++ b/FreeRTOS/Demo/msp430_CrossWorks/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/msp430_CrossWorks/serial/serial.c
+++ b/FreeRTOS/Demo/msp430_CrossWorks/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/msp430_CrossWorks/serial/serialASM.asm
+++ b/FreeRTOS/Demo/msp430_CrossWorks/serial/serialASM.asm
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/msp430_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/msp430_GCC/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/msp430_GCC/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/msp430_GCC/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/msp430_GCC/main.c
+++ b/FreeRTOS/Demo/msp430_GCC/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/msp430_GCC/makefile
+++ b/FreeRTOS/Demo/msp430_GCC/makefile
@@ -1,5 +1,5 @@
 #/*
-# * FreeRTOS Kernel V10.4.1
+# * FreeRTOS V202011.00
 # * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 # *
 # * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/msp430_GCC/serial/serial.c
+++ b/FreeRTOS/Demo/msp430_GCC/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/msp430_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/msp430_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/msp430_IAR/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/msp430_IAR/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/msp430_IAR/main.c
+++ b/FreeRTOS/Demo/msp430_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/msp430_IAR/serial/serial.c
+++ b/FreeRTOS/Demo/msp430_IAR/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/msp430_IAR/serial/serialASM.s43
+++ b/FreeRTOS/Demo/msp430_IAR/serial/serialASM.s43
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/History.txt
+++ b/FreeRTOS/History.txt
@@ -1,5 +1,21 @@
 Documentation and download available at https://www.FreeRTOS.org/
 
+Changes between FreeRTOS V10.4.1 and FreeRTOS V202011.00 released November 10 2020
+
+	+ Added new coreJSON Library. See https://www.freertos.org/json/
+	+ Added new coreMQTT Library. See https://www.freertos.org/mqtt/
+	+ Added new corePKCS11 Library. See https://www.freertos.org/pkcs11/
+	+ Added new AWS IoT Device Shadow Library. See
+	  https://www.freertos.org/iot-device-shadow/
+	+ Updated to FreeRTOS Kernel v10.4.2. See
+	  https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/master/History.txt
+	+ Updated to FreeRTOS+TCP v2.3.1. See
+	  https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/master/History.txt
+	+ Update WolfSSL to 4.5.0 and add the WolfSSL FIPS ready demo.
+	+ Convert most dependent libraries to Git submodules.
+	+ Various general maintenance and improvements.
+
+
 Changes between FreeRTOS V10.4.0 and FreeRTOS V10.4.1 released September 17 2020
 	See https://www.FreeRTOS.org/FreeRTOS-V10.4.x.html
 

--- a/FreeRTOS/Test/CBMC/patches/FreeRTOSConfig.h
+++ b/FreeRTOS/Test/CBMC/patches/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.1
+ * FreeRTOS V202011.00
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Test/CBMC/patches/FreeRTOSIPConfig.h
+++ b/FreeRTOS/Test/CBMC/patches/FreeRTOSIPConfig.h
@@ -1,5 +1,5 @@
 /*
-FreeRTOS Kernel V10.4.1
+FreeRTOS V202011.00
 Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of


### PR DESCRIPTION
#### Problem \n When there are different definitions of `SdkLog` in different config files (like `demo_config.h` and `core_mqtt_config.h` files) and the config files are included in the same translation unit, there is compiler warning of conflicting definitions. \n #### Fix \n Add `#ifndef` guards around the `SdkLog` definitions in config files to avoid multiple definitions in a translation unit. \n #### Note For most cases, the user may need to define the `SdkLog` macro ONLY once for the entire project build. An alternative way to define the macro for the whole project is by setting its default value in the `FreeRTOS-Plus/Source/Utilities/Logging/logging_stack.h` file